### PR TITLE
Add supports for `--scripts-version`

### DIFF
--- a/packages/react-app-rewired/config/paths.js
+++ b/packages/react-app-rewired/config/paths.js
@@ -1,0 +1,11 @@
+const path = require('path');
+const fs = require('fs');
+const scriptVersion = process.argv[2] || 'react-scripts';
+const projectDir = path.resolve(fs.realpathSync(process.cwd()));
+const scriptVersionDir = path.join(projectDir, 'node_modules', scriptVersion);
+
+module.exports = {
+    scriptVersion,
+    projectDir,
+    scriptVersionDir,
+};

--- a/packages/react-app-rewired/scripts/build.js
+++ b/packages/react-app-rewired/scripts/build.js
@@ -3,10 +3,12 @@ process.env.NODE_ENV = 'production';
 
 const fs = require('fs');
 const path = require('path');
-const config = require('react-scripts/config/webpack.config.prod');
-const override = require(path.resolve(fs.realpathSync(process.cwd()) + '/config-overrides'));
+const paths = require('../config/paths');
+const webpackConfig = paths.scriptVersionDir + '/config/webpack.config.prod';
+const config = require(webpackConfig);
+const override = require(paths.projectDir + '/config-overrides');
 
-require.cache[require.resolve('react-scripts/config/webpack.config.prod')].exports =
+require.cache[require.resolve(webpackConfig)].exports =
   override(config, process.env.NODE_ENV);
 
-require('react-scripts/scripts/build');
+require(paths.scriptVersionDir + '/scripts/build');

--- a/packages/react-app-rewired/scripts/start.js
+++ b/packages/react-app-rewired/scripts/start.js
@@ -1,10 +1,12 @@
 /* start.js */
 const fs = require('fs');
 const path = require('path');
-const config = require('react-scripts/config/webpack.config.dev');
-const override = require(path.resolve(fs.realpathSync(process.cwd()) + '/config-overrides'));
+const paths = require('../config/paths');
+const webpackConfig = paths.scriptVersionDir + '/config/webpack.config.dev';
+const config = require(webpackConfig);
+const override = require(paths.projectDir + '/config-overrides');
 
-require.cache[require.resolve('react-scripts/config/webpack.config.dev')].exports =
+require.cache[require.resolve(webpackConfig)].exports =
   override(config, process.env.NODE_ENV || 'development');
 
-require('react-scripts/scripts/start');
+require(paths.scriptVersionDir + '/scripts/start');


### PR DESCRIPTION
We could use  `--scripts-version` in CRA to create react app,
Once app is created,  we should specify `scripts-version` instead of default `react-scripts`, Otherwise we'll get `Error: Cannot find module 'react-scripts'`.

Usage example:

```js
/* package.json */

"scripts": {
    "start": "react-app-rewired start my-react-scripts",
    "build": "react-app-rewired build my-react-scripts"
}
```