### PR TITLE
Fix custom scripts didn't works and use `--scripts-version` to specify

### DIFF
--- a/packages/react-app-rewired/config/paths.js
+++ b/packages/react-app-rewired/config/paths.js
@@ -14,17 +14,10 @@ var fs = require('fs');
 
 
 //try to detect if user is using a custom scripts version
-var custom_scripts = Object
-    .keys(process.argv)
-    .filter(key => {
-      if(process.argv[key].indexOf("--scripts-version") ==-1) return false;
+var custom_scripts = process.argv.indexOf('--scripts-version');
 
-      return process.argv[key];
-    });
-
-
-if(custom_scripts){
-  custom_scripts = process.argv[custom_scripts];
+if(custom_scripts > -1 && custom_scripts <= process.argv.length){
+  custom_scripts = process.argv[custom_scripts + 1];
 }
 
 

--- a/packages/react-app-rewired/config/paths.js
+++ b/packages/react-app-rewired/config/paths.js
@@ -16,7 +16,7 @@ var fs = require('fs');
 //try to detect if user is using a custom scripts version
 var custom_scripts = process.argv.indexOf('--scripts-version');
 
-if(custom_scripts > -1 && custom_scripts <= process.argv.length){
+if(custom_scripts > -1 && custom_scripts + 1 <= process.argv.length){
   custom_scripts = process.argv[custom_scripts + 1];
 }
 


### PR DESCRIPTION
After the commit cb53dd3771d2947f25d8f39bd899f51ba7453da2 as well as version `0.6.1`, custom scripts didn't works anymore.

This PR going to fixing it and change the CLI specification.

For example, the original `build` run-scripts with custom scripts:
```js
"scripts": {
  "build": "react-app-rewired build react-scripts-jihchi"
}
```
Change to 
```js
"scripts": {
  "build": "react-app-rewired build --scripts-version react-scripts-jihchi"
}
```
Which is same with CRA argument.