### PR TITLE
Add react-app-rewire-less

### DIFF
--- a/packages/react-app-rewire-less/README.md
+++ b/packages/react-app-rewire-less/README.md
@@ -1,6 +1,6 @@
 # Rewire create-react-app to use LESS!
 
-You might not need this rewire, Create React App added guide about how to add Less support to CRA without the need of ejecting. See [Adding a CSS Preprocessor] section of CRA guide. Also note, that their solution is based on compiling Less without using Webpack.
+You might not need this rewire, Create React App added guide about how to add Less support to CRA without the need of ejecting. See [Adding a CSS Preprocessor](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-a-css-preprocessor-sass-less-etc) section of CRA guide. Also note, that their solution is based on compiling Less without using Webpack.
 
 # Install
 

--- a/packages/react-app-rewire-less/README.md
+++ b/packages/react-app-rewire-less/README.md
@@ -1,0 +1,23 @@
+# Rewire create-react-app to use LESS!
+
+You might not need this rewire, Create React App added guide about how to add Less support to CRA without the need of ejecting. See [Adding a CSS Preprocessor] section of CRA guide. Also note, that their solution is based on compiling Less without using Webpack.
+
+# Install
+
+```bash
+$ npm install --save react-app-rewire-less
+```
+
+# Add it to your project
+
+* [Rewire your app](https://github.com/timarney/react-app-rewired#how-to-rewire-your-create-react-app-project) than modify `config-overrides.js`
+
+```javascript
+const rewireLess = require('react-app-rewire-less');
+
+/* config-overrides.js */
+module.exports = function override(config, env) {
+  config = rewireLess(config, env);
+  return config;
+}
+```

--- a/packages/react-app-rewire-less/index.js
+++ b/packages/react-app-rewire-less/index.js
@@ -1,0 +1,20 @@
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+const urlLoader = function (conf) {
+  return conf.loader === 'url';
+};
+
+function rewireLess (config, env) {
+  config.module.loaders.find(urlLoader).exclude.push(/\.less$/);
+
+  config.module.loaders.push({
+    test: /\.less$/,
+    loader: (env === 'development')
+      ? 'style!css!less'
+      : ExtractTextPlugin.extract('style', 'css!less')
+  });
+
+  return config;
+}
+
+module.exports = rewireLess;

--- a/packages/react-app-rewire-less/package.json
+++ b/packages/react-app-rewire-less/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "react-app-rewire-less",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "extract-text-webpack-plugin": "^1.0.1",
+    "less": "^2.7.2",
+    "less-loader": "^2.2.3",
+    "webpack": "^1.14.0"
+  }
+}


### PR DESCRIPTION
I tested it on small project with Less

- both development and build mode works
- locally tested it by adding this to my small project dependency (not sure if there is better way to test unreleased modules from different repositories/packages):
```json
  "devDependencies": {
    "react-app-rewire-less": "../../../_tmp/react-app-rewired/packages/react-app-rewire-less",
    ...
  }
```