### PR TITLE
Less rewire: webpack2 CRA 0.10 support

### DIFF
--- a/packages/react-app-rewire-less/index.js
+++ b/packages/react-app-rewire-less/index.js
@@ -1,18 +1,57 @@
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+function rewireLess (config, env, lessLoaderOptions = {}) {
+  const lessExtension = /\.less$/;
 
-const urlLoader = function (conf) {
-  return conf.loader === 'url';
-};
+  config.module.rules
+    .find(m => m.loader === 'file-loader')
+    .exclude.push(lessExtension);
 
-function rewireLess (config, env) {
-  config.module.loaders.find(urlLoader).exclude.push(/\.less$/);
+  const cssRules = config.module.rules.find(m => String(m.test) === String(/\.css$/));
 
-  config.module.loaders.push({
-    test: /\.less$/,
-    loader: (env === 'development')
-      ? 'style!css!less'
-      : ExtractTextPlugin.extract('style', 'css!less')
-  });
+  let lessRules;
+  if (env === 'production') {
+    const cssLoaders = cssRules.loader;
+    if (!cssLoaders || cssLoaders.length !== 4) {
+      throw new Error('Unexpected CRA CSS loaders configuration');
+    }
+
+    const [
+      extractTextLoader,
+      styleLoader,
+      cssLoader,
+      postCssLoader
+    ] = cssLoaders;
+
+    lessRules = {
+      test: lessExtension,
+      loader: [
+        extractTextLoader,
+        styleLoader,
+        cssLoader,
+        { loader: 'less-loader', options: lessLoaderOptions },
+        postCssLoader
+      ]
+    };
+  } else {
+    const cssLoaders = cssRules.use;
+
+    if (!cssLoaders || cssLoaders.length !== 3) {
+      throw new Error('Unexpected CRA CSS loaders configuration');
+    }
+
+    const [styleLoader, cssLoader, postCssLoader] = cssLoaders;
+
+    lessRules = {
+      test: lessExtension,
+      use: [
+        styleLoader,
+        cssLoader,
+        { loader: 'less-loader', options: lessLoaderOptions },
+        postCssLoader
+      ]
+    };
+  }
+
+  config.module.rules.push(lessRules);
 
   return config;
 }

--- a/packages/react-app-rewire-less/index.js
+++ b/packages/react-app-rewire-less/index.js
@@ -2,10 +2,10 @@ function rewireLess (config, env, lessLoaderOptions = {}) {
   const lessExtension = /\.less$/;
 
   config.module.rules
-    .find(m => m.loader === 'file-loader')
+    .find(rule => rule.loader === 'file-loader')
     .exclude.push(lessExtension);
 
-  const cssRules = config.module.rules.find(m => String(m.test) === String(/\.css$/));
+  const cssRules = config.module.rules.find(rule => String(rule.test) === String(/\.css$/));
 
   let lessRules;
   if (env === 'production') {
@@ -33,7 +33,6 @@ function rewireLess (config, env, lessLoaderOptions = {}) {
     };
   } else {
     const cssLoaders = cssRules.use;
-
     if (!cssLoaders || cssLoaders.length !== 3) {
       throw new Error('Unexpected CRA CSS loaders configuration');
     }

--- a/packages/react-app-rewire-less/package.json
+++ b/packages/react-app-rewire-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-app-rewire-less",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -8,9 +8,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "extract-text-webpack-plugin": "^1.0.1",
     "less": "^2.7.2",
-    "less-loader": "^2.2.3",
-    "webpack": "^1.14.0"
+    "less-loader": "^4.0.2",
+    "webpack": "^2.3.2"
   }
 }


### PR DESCRIPTION
First version of Less loader support for CRA 0.10.

How it works
- Create new less rules
- Find CSS loader chain (style-loader <-> css-loader <-> postcss)
- Add new Less rules - reuse the CSS chain with less-loader injected at the right place (style-loader <-> css-loader <-> less-loader <-> postcss)

Few notes/questions:
- I am reusing loaders from the CSS rules, can this cause any problems?
- I am not experienced with webpack2, so some code review to make sure I am not doing anything stupid would be helpful
- Since I am reusing existing loader chain and putting new loader at a specific position, I thought it might be useful to add some basic loaders validation. Right now it just takes a look if the thing exists and if it has a correct number of loaders. I think some validation might be useful for these more 'fragile' Webpack config modifications.
  - Is there some better way to validate the structure of maybe some other less fragile way to do what I am trying to do?
- CRA CSS loader remains unaffected, so users will still be able to import CSS files (CSS is then mixed in the same bundle along with the compiled Less)
- Sass support should be identical - just switching the Less for Sass + changing dependencies should be enough. Maybe we could extract this logic into shared function across these two repositories. Is there some way to have shared module, between these two packages, without making the function another separate package?