### PR TITLE
Update Less rewire to make it work with CRA 1.0.0

### DIFF
--- a/packages/react-app-rewire-less/package.json
+++ b/packages/react-app-rewire-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-app-rewire-less",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,6 @@
   "license": "MIT",
   "dependencies": {
     "less": "^2.7.2",
-    "less-loader": "^4.0.2",
-    "webpack": "^2.3.2"
+    "less-loader": "^4.0.3"
   }
 }


### PR DESCRIPTION
- Updated Less rewire to CRA 1.0.0.
- The previous version that I prepared and you published was broken thanks to some breaking changes between canary and the 1.0.0 release.
- Has issues with relative paths that I mentioned in https://github.com/timarney/react-app-rewired/issues/33