### PR TITLE
Fix execution error in start command

### DIFF
--- a/packages/react-app-rewired/scripts/start.js
+++ b/packages/react-app-rewired/scripts/start.js
@@ -1,4 +1,5 @@
 /* start.js */
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 // Load environment variables from .env file. Suppress warnings using silent
 // if this file is missing. dotenv will never modify any environment variables
@@ -14,6 +15,6 @@ const config = require(webpackConfig);
 const override = require(paths.projectDir + '/config-overrides');
 
 require.cache[require.resolve(webpackConfig)].exports =
-  override(config, process.env.NODE_ENV || 'development');
+  override(config, process.env.NODE_ENV);
 
 require(paths.scriptVersionDir + '/scripts/start');


### PR DESCRIPTION
react-scripts 1.x needs NODE_ENV environment variable.
This feature was added 9 days ago. see [detail](https://github.com/facebookincubator/create-react-app/commit/80a7fc391df112bcb9f2c669b3932d4b3d0856fc).
This pull request fix execution error in start command.

Details about error messages are found below.

package.json
```
{
  "scripts": {
    "start": "react-app-rewired start"
  }
}
```

Error occurs when I run command "yarn start"

```
yarn start v0.24.5
$ node ../packages/react-app-rewired/bin/index.js start
/Users/haydn/Development/react-app-rewired2/test/node_modules/react-scripts/config/env.js:22
  throw new Error(
  ^

Error: The NODE_ENV environment variable is required but was not specified.
    at Object.<anonymous> (/Users/haydn/Development/react-app-rewired2/test/node_modules/react-scripts/config/env.js:22:9)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/haydn/Development/react-app-rewired2/test/node_modules/react-scripts/config/webpack.config.dev.js:22:30)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
error Command failed with exit code 1.
```