### PR TITLE
Add react-app-rewire-styled-components

### DIFF
--- a/packages/react-app-rewire-styled-components/index.js
+++ b/packages/react-app-rewire-styled-components/index.js
@@ -1,0 +1,12 @@
+const babelLoader = function (conf) {
+  return conf.loader === 'babel';
+};
+
+function rewireStyledComponents(config, env) {
+  const babelrc = config.module.loaders.find(babelLoader).query;
+  babelrc.plugins = ['styled-components'].concat(babelrc.plugins || []);
+
+  return config;
+}
+
+module.exports = rewireStyledComponents;

--- a/packages/react-app-rewire-styled-components/package.json
+++ b/packages/react-app-rewire-styled-components/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "react-app-rewire-styled-components",
+  "version": "1.0.0",
+  "description": "rewire your react-app and use styled-components",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "babel-plugin-styled-components": "^1.1.4"
+  },
+  "peerDependencies": {
+    "styled-components": "2.x"
+  }
+}


### PR DESCRIPTION
Adds `babel-plugin-styled-components` to the Babel plugins.

> Note: I didn't test this manually, I copied the code from the Relay version and just replaced `react-relay` with `babel-plugin-styled-components`.