### PR TITLE
Make Jest configurable from package.json

### DIFF
--- a/packages/react-app-rewired/scripts/utils/createJestConfig.js
+++ b/packages/react-app-rewired/scripts/utils/createJestConfig.js
@@ -49,42 +49,23 @@ module.exports = (resolve, rootDir, isEjecting) => {
     config.rootDir = rootDir;
   }
   const overrides = Object.assign({}, require(paths.appPackageJson).jest);
-  const supportedKeys = [
-    'collectCoverageFrom',
-    'coverageReporters',
-    'coverageThreshold',
-    'snapshotSerializers',
-  ];
-  if (overrides) {
-    supportedKeys.forEach(key => {
-      if (overrides.hasOwnProperty(key)) {
+  
+  // Jest configuration in package.json will be added to the the default config
+  Object.keys(overrides)
+    .forEach(key => {
+      //We don't overwrite the default config, but add to each property if not a string
+      if(config[key]) {
+        if(typeof overrides[key] === 'string') {
+          config[key] = overrides[key];
+        } else if(Array.isArray(typeof overrides[key])) {
+          config[key] = overrides[key].concat(config[key]);
+        }
+        else if(typeof overrides[key] === 'object') {
+          config[key] = Object.assign({}, overrides[key], config[key]);
+        }
+      } else {
         config[key] = overrides[key];
-        delete overrides[key];
       }
     });
-    const unsupportedKeys = Object.keys(overrides);
-    if (unsupportedKeys.length) {
-      console.error(
-        chalk.red(
-          'Out of the box, Create React App only supports overriding ' +
-            'these Jest options:\n\n' +
-            supportedKeys.map(key => chalk.bold('  \u2022 ' + key)).join('\n') +
-            '.\n\n' +
-            'These options in your package.json Jest configuration ' +
-            'are not currently supported by Create React App:\n\n' +
-            unsupportedKeys
-              .map(key => chalk.bold('  \u2022 ' + key))
-              .join('\n') +
-            '\n\nIf you wish to override other Jest options, you need to ' +
-            'eject from the default setup. You can do so by running ' +
-            chalk.bold('npm run eject') +
-            ' but remember that this is a one-way operation. ' +
-            'You may also file an issue with Create React App to discuss ' +
-            'supporting more options out of the box.\n'
-        )
-      );
-      process.exit(1);
-    }
-  }
   return config;
 };


### PR DESCRIPTION
react-app-rewired purpose is to be able to add custom configuration while keeping default react-scripts config.
That's working great, but I found out `react-app-rewired test` is not configurable.

react-scripts recently enabled some keys to be overwritten, but here we'd like to enable all to be overwritten...

package.json

```
{
 "name": "app",
 "jest" : {
  "transform" : {
      "^.+\\.(graphql|gql)$": "jest-transform-graphql"
   }
 }
}

```
will ADD this transform property to all defaults