### PR TITLE
Fix react-app-rewire-less not working on Windows

### DIFF
--- a/packages/react-app-rewire-less/index.js
+++ b/packages/react-app-rewire-less/index.js
@@ -1,8 +1,10 @@
+const path = require('path')
+
 function rewireLess (config, env, lessLoaderOptions = {}) {
   const lessExtension = /\.less$/;
 
   const fileLoader = config.module.rules
-    .find(rule => rule.loader && rule.loader.endsWith('/file-loader/index.js'));
+    .find(rule => rule.loader && rule.loader.endsWith(`${path.sep}file-loader${path.sep}index.js`));
   fileLoader.exclude.push(lessExtension);
 
   const cssRules = config.module.rules


### PR DESCRIPTION
Closes #53