### PR TITLE
Fix plugin injection on Windows

### DIFF
--- a/packages/react-app-rewired/index.js
+++ b/packages/react-app-rewired/index.js
@@ -1,5 +1,7 @@
+const path = require('path');
+
 const babelLoaderMatcher = function(rule) {
-  return rule.loader && rule.loader.indexOf("babel-loader/") != -1;
+  return rule.loader && rule.loader.indexOf(`babel-loader${path.sep}`) != -1;
 }
 
 const getLoader = function(rules, matcher) {


### PR DESCRIPTION
Since Windows uses backslashes as path separators they need to be treated differently. 

Fixes: #77 