### PR TITLE
Make `injectBabelPlugin` compatible with older webpack versions

### DIFF
--- a/packages/react-app-rewired/index.js
+++ b/packages/react-app-rewired/index.js
@@ -26,7 +26,10 @@ const injectBabelPlugin = function(pluginName, config) {
     console.log("babel-loader not found");
     return config;
   }
-  loader.options.plugins = [pluginName].concat(loader.options.plugins || []);
+  
+  // Older versions of webpack have `plugins` on `loader.query` instead of `loader.options`.
+  const options = loader.options || loader.query;
+  options.plugins = [pluginName].concat(options.plugins || []);
   return config;
 };
 


### PR DESCRIPTION
Specifically, this is needed for people using React StoryBook.