### PR TITLE
WebpackDevServer config override

### DIFF
--- a/packages/react-app-rewired/config-overrides.js
+++ b/packages/react-app-rewired/config-overrides.js
@@ -11,6 +11,28 @@ module.exports = {
   },
   jest: function (config) {
     return config;
+  },
+  // configFunction is the original react-scripts function that creates the
+  // Webpack Dev Server config based on the settings for proxy/allowedHost.
+  // react-scripts injects this into your function (so you can use it to
+  // create the standard config to start from), and needs to receive back a
+  // function that takes the same arguments as the original react-scripts
+  // function so that it can be used as a replacement for the original one.
+  devServer: function (configFunction) {
+    return function(proxy, allowedHost) {
+      const config = configFunction(proxy, allowedHost);
+      // Edit config here - example: set your own certificates.
+      //
+      // const fs = require('fs');
+      // config.https = {
+      //   key: fs.readFileSync(process.env.REACT_HTTPS_KEY, 'utf8'),
+      //   cert: fs.readFileSync(process.env.REACT_HTTPS_CERT, 'utf8'),
+      //   ca: fs.readFileSync(process.env.REACT_HTTPS_CA, 'utf8'),
+      //   passphrase: process.env.REACT_HTTPS_PASS
+      // };
+      
+      return config;
+    };
   }
 }
 */

--- a/packages/react-app-rewired/scripts/start.js
+++ b/packages/react-app-rewired/scripts/start.js
@@ -18,4 +18,12 @@ const overrideFn = typeof override === 'function'
 require.cache[require.resolve(webpackConfig)].exports =
   overrideFn(config, process.env.NODE_ENV);
 
+if (typeof override !== 'function' && typeof override.devServer === 'function') {
+  const devServerConfig = paths.scriptVersion + '/config/webpackDevServer.config.js';
+  const devServerRewire = require(devServerConfig);
+
+  require.cache[require.resolve(devServerConfig)].exports =
+    override.devServer(devServerRewire);
+}
+
 require(paths.scriptVersion + '/scripts/start');


### PR DESCRIPTION
Allow people to override the webpack dev server config used when doing 'yarn run start', so that things like setting specific https certificates can be done.