### PR TITLE
Ensure environment variables are read

### DIFF
--- a/packages/react-app-rewired/scripts/build.js
+++ b/packages/react-app-rewired/scripts/build.js
@@ -9,6 +9,7 @@ require('dotenv').config({silent: true});
 
 const paths = require('./utils/paths');
 const webpackConfig = paths.scriptVersion + '/config/webpack.config.prod';
+require(paths.scriptVersion + '/config/env');
 const config = require(webpackConfig);
 const override = require(paths.configOverrides);
 const overrideFn = typeof override === 'function'

--- a/packages/react-app-rewired/scripts/start.js
+++ b/packages/react-app-rewired/scripts/start.js
@@ -9,6 +9,7 @@ require('dotenv').config({silent: true});
 
 const paths = require('./utils/paths');
 const webpackConfig = paths.scriptVersion + '/config/webpack.config.dev';
+require(paths.scriptVersion + '/config/env');
 const config = require(webpackConfig);
 const override = require(paths.configOverrides);
 const overrideFn = typeof override === 'function'

--- a/packages/react-app-rewired/scripts/test.js
+++ b/packages/react-app-rewired/scripts/test.js
@@ -2,6 +2,7 @@ const path = require("path");
 const paths = require("./utils/paths");
 
 const jestConfigPath = paths.scriptVersion + "/scripts/utils/createJestConfig";
+require(paths.scriptVersion + '/config/env');
 const createJestConfig = require(jestConfigPath);
 const rewireJestConfig = require("./utils/rewireJestConfig");
 const override = require(paths.configOverrides);


### PR DESCRIPTION
So must require env before require webpackConfig and jestConfig, otherwise, the environment-specific settings will not work, see [create-react-app](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/scripts/test.js#L25-L26)