### PR TITLE
Fix priority order in .env files loading and fail safe NODE_ENV in test.js

### DIFF
--- a/packages/react-app-rewired/scripts/build.js
+++ b/packages/react-app-rewired/scripts/build.js
@@ -1,11 +1,8 @@
 /* build.js */
 process.env.NODE_ENV = 'production';
 
-// Load environment variables from .env file. Suppress warnings using silent
-// if this file is missing. dotenv will never modify any environment variables
-// that have already been set.
-// https://github.com/motdotla/dotenv
-require('dotenv').config({silent: true});
+// Load environment variables from .env files
+require("react-scripts/config/env");
 
 const paths = require('./utils/paths');
 const webpackConfig = paths.scriptVersion + '/config/webpack.config.prod';

--- a/packages/react-app-rewired/scripts/start.js
+++ b/packages/react-app-rewired/scripts/start.js
@@ -1,11 +1,8 @@
 /* start.js */
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-// Load environment variables from .env file. Suppress warnings using silent
-// if this file is missing. dotenv will never modify any environment variables
-// that have already been set.
-// https://github.com/motdotla/dotenv
-require('dotenv').config({silent: true});
+// Load environment variables from .env files
+require("react-scripts/config/env");
 
 const paths = require('./utils/paths');
 const webpackConfig = paths.scriptVersion + '/config/webpack.config.dev';

--- a/packages/react-app-rewired/scripts/test.js
+++ b/packages/react-app-rewired/scripts/test.js
@@ -1,6 +1,8 @@
 const path = require("path");
 const paths = require("./utils/paths");
 
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+
 const jestConfigPath = paths.scriptVersion + "/scripts/utils/createJestConfig";
 require(paths.scriptVersion + '/config/env');
 const createJestConfig = require(jestConfigPath);


### PR DESCRIPTION
Fixes #98 

Also fixes this issue when running `react-app-rewired test --env=jsdom`

```
> react-app-rewired test --env=jsdom

/Users/andreas/Code/foobar/node_modules/react-scripts/config/env.js:22
  throw new Error(
  ^

Error: The NODE_ENV environment variable is required but was not specified.

```