### PR TITLE
Make the --scripts-version option work with tests.

### DIFF
--- a/packages/react-app-rewired/scripts/test.js
+++ b/packages/react-app-rewired/scripts/test.js
@@ -29,4 +29,10 @@ packageJson.jest = jestOverrides;
 require.cache[require.resolve(jestConfigPath)].exports =
   () => overrideFn(rewireJestConfig(config));
 
+// Passing the --scripts-version on to the original test script can result
+// in the test script rejecting it as an invalid option. So strip it out of
+// the command line arguments before invoking the test script.
+if (paths.customScriptsIndex > -1) {
+  process.argv.splice(paths.customScriptsIndex, 2);
+}
 require(paths.scriptVersion + '/scripts/test');

--- a/packages/react-app-rewired/scripts/utils/paths.js
+++ b/packages/react-app-rewired/scripts/utils/paths.js
@@ -2,12 +2,11 @@ var path = require('path');
 var fs = require('fs');
 
 //try to detect if user is using a custom scripts version
-var custom_scripts = process.argv.indexOf('--scripts-version');
+var custom_scripts = false;
+const cs_index = process.argv.indexOf('--scripts-version');
 
-if (custom_scripts > -1 && custom_scripts + 1 <= process.argv.length) {
-  custom_scripts = process.argv[custom_scripts + 1];
-} else {
-  custom_scripts = false;
+if (cs_index > -1 && cs_index + 1 <= process.argv.length) {
+  custom_scripts = process.argv[cs_index + 1];
 }
 
 const scriptVersion = custom_scripts || 'react-scripts';
@@ -17,5 +16,6 @@ const paths = require(scriptVersion + '/config/paths');
 
 module.exports = Object.assign({
   scriptVersion: scriptVersion,
-  configOverrides: projectDir + '/config-overrides'
+  configOverrides: projectDir + '/config-overrides',
+  customScriptsIndex: (custom_scripts ? cs_index : -1)
 }, paths);


### PR DESCRIPTION
Using react-scripts-ts as the scripts version results in the test script
failing due to "--scripts-version" being an unsupported option for the
react-scripts-ts test script.

Since that option is only of relevance to react-app-rewired, strip it out
of the list of arguments before passing those on to the called test script.