### PR TITLE
update mobx peerDependencies to allow React 16

### DIFF
--- a/packages/react-app-rewire-mobx/package.json
+++ b/packages/react-app-rewire-mobx/package.json
@@ -11,7 +11,7 @@
     "babel-plugin-transform-decorators-legacy": "1.3.4"
   },
   "peerDependencies": {
-    "react": ">=15.6.0 < 16",
+    "react": ">=15.6.0 < 17",
     "mobx": ">=3.1.17 < 4",
     "mobx-react": ">=4.2.2 < 5"
   }


### PR DESCRIPTION
avoiding npm warning 😄