### PR TITLE
Update react-app-rewired bin to allow node arguments

### DIFF
--- a/packages/react-app-rewired/bin/index.js
+++ b/packages/react-app-rewired/bin/index.js
@@ -1,39 +1,49 @@
 #!/usr/bin/env node
 var spawn = require('cross-spawn');
-var script = process.argv[2];
-var args = process.argv.slice(3);
+const args = process.argv.slice(2);
+
+const scriptIndex = args.findIndex(
+  x => x === 'build' || x === 'eject' || x === 'start' || x === 'test'
+);
+const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
+const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : [];
 
 switch (script) {
-case 'build':
-case 'eject':
-case 'start':
-case 'test':
-  var result = spawn.sync(
-    'node',
-    [require.resolve('../scripts/' + script)].concat(args),
-    {stdio: 'inherit'}
-  );
-  if (result.signal) {
-    if (result.signal == 'SIGKILL') {
-      console.log(
-        'The build failed because the process exited too early. ' +
-        'This probably means the system ran out of memory or someone called ' +
-        '`kill -9` on the process.'
-      );
-    } else if (result.signal == 'SIGTERM') {
-      console.log(
-        'The build failed because the process exited too early. ' +
-        'Someone might have called `kill` or `killall`, or the system could ' +
-        'be shutting down.'
-      );
+  case 'build':
+  case 'eject':
+  case 'start':
+  case 'test': {
+    const result = spawn.sync(
+      'node',
+      nodeArgs
+        .concat(require.resolve('../scripts/' + script))
+        .concat(args.slice(scriptIndex + 1)),
+      { stdio: 'inherit' }
+    );
+    if (result.signal) {
+      if (result.signal === 'SIGKILL') {
+        console.log(
+          'The build failed because the process exited too early. ' +
+            'This probably means the system ran out of memory or someone called ' +
+            '`kill -9` on the process.'
+        );
+      } else if (result.signal === 'SIGTERM') {
+        console.log(
+          'The build failed because the process exited too early. ' +
+            'Someone might have called `kill` or `killall`, or the system could ' +
+            'be shutting down.'
+        );
+      }
+      process.exit(1);
     }
-    process.exit(1);
+    process.exit(result.status);
+    break;
   }
-  process.exit(result.status);
-  break;
-default:
-  console.log('Unknown script "' + script + '".');
-  console.log('Perhaps you need to update react-scripts?');
-  console.log('See: https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#updating-to-new-releases');
-  break;
+  default:
+    console.log('Unknown script "' + script + '".');
+    console.log('Perhaps you need to update react-scripts?');
+    console.log(
+      'See: https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#updating-to-new-releases'
+    );
+    break;
 }


### PR DESCRIPTION
Updates the bin file to match latest react-scripts bin in CRA (v1.0.14). This allows users to pass node arguments to our process, eg the --inspect flag for debugging tests.