### PR TITLE
 Add compose for rewires

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ $ npm run build
 ```
 
 
-## Utilities (injectBabelPlugin)
+## Utilities 
+
+#### 1) injectBabelPlugin
 
 Adding a Babel plugin can be done via the `injectBabelPlugin(pluginName, config)` function.  You can also use the "rewire" packages from this repo or listed below to do common config modifications.
 
@@ -95,6 +97,49 @@ module.exports = function override(config, env) {
   return config;
 }
 ```
+
+#### 2) compose(after v1.3.4)
+
+You can use this util to `compose` rewires.
+Before:
+```javascript
+/* config-overrides.js */
+module.exports = function override(config, env) {
+  config = rewireLess(config, env);
+  config = rewirePreact(config, env);
+  config = rewireMobX(config,env);
+  
+  return config;
+}
+```
+After use `compose`:
+```javascript
+/* config-overrides.js */
+const { compose } = require('react-app-reiwred');
+
+module.exports = compose(
+  rewireLess,
+  rewirePreact,
+  rewireMobx
+  ...
+)
+//  custom config 
+module.exports = function(config, env){
+  const applyedRewires = compose(
+    rewireLess,
+    rewirePreact,
+    rewireMobx
+    ...
+  );
+  // do custom config
+  // ...
+  return applyedReiwres(config, env);
+}
+```
+Some change with rewire:
+if you want set some `extra param` for `rewire`, you can see (react-app-rewire-less)[https://github.com/timarney/react-app-rewired/blob/master/packages/react-app-rewire-less/index.js]
+
+
 
 # Community Maintained Rewires
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ you can see [react-app-rewire-less](https://github.com/timarney/react-app-rewire
 2. Required params:  
 ```javascript
 // rewireSome.js
-const createRewire(requiredParams){
+function createRewire(requiredParams){
   return function rewire(config, env){
     ///
     return config

--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ you can see [react-app-rewire-less](https://github.com/timarney/react-app-rewire
 
 2. Required params:  
 ```javascript
+// rewireSome.js
 const createRewire(requiredParams){
-  return rewire(config, env){
+  return function rewire(config, env){
     ///
     return config
   }

--- a/README.md
+++ b/README.md
@@ -136,8 +136,20 @@ module.exports = function(config, env){
   return applyedReiwres(config, env);
 }
 ```
-Some change with rewire:
-if you want set some `extra param` for `rewire`, you can see [react-app-rewire-less](https://github.com/timarney/react-app-rewired/blob/master/packages/react-app-rewire-less/index.js)
+Some change with rewire, if you want to add some `extra param` for `rewire`  
+1. Optional params:  
+you can see [react-app-rewire-less](https://github.com/timarney/react-app-rewired/blob/master/packages/react-app-rewire-less/index.js)  
+
+2. Required params:  
+```javascript
+const createRewire(requiredParams){
+  return rewire(config, env){
+    ///
+    return config
+  }
+}
+module.exports = createRewire;
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ module.exports = function(config, env){
 }
 ```
 Some change with rewire:
-if you want set some `extra param` for `rewire`, you can see (react-app-rewire-less)[https://github.com/timarney/react-app-rewired/blob/master/packages/react-app-rewire-less/index.js]
+if you want set some `extra param` for `rewire`, you can see [react-app-rewire-less](https://github.com/timarney/react-app-rewired/blob/master/packages/react-app-rewire-less/index.js)
 
 
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ module.exports = function override(config, env) {
 
 #### 2) compose(after v1.3.4)
 
-You can use this util to `compose` rewires.
+You can use this util to compose rewires.
+> A functional programming utility, performs `right-to-left` function composition.     
+More detail you can see [ramda](http://ramdajs.com/docs/#compose) or [redux](http://redux.js.org/docs/api/compose.html#composefunctions)  
+
 Before:
 ```javascript
 /* config-overrides.js */

--- a/packages/react-app-rewire-less/README.md
+++ b/packages/react-app-rewire-less/README.md
@@ -18,6 +18,8 @@ const rewireLess = require('react-app-rewire-less');
 /* config-overrides.js */
 module.exports = function override(config, env) {
   config = rewireLess(config, env);
+  // with loaderOptions
+  // config = rewireLess.withLoaderOptions(someLoaderOptions)(config, env);
   return config;
 }
 ```

--- a/packages/react-app-rewire-less/index.js
+++ b/packages/react-app-rewire-less/index.js
@@ -1,44 +1,55 @@
 const path = require('path');
 const { getLoader } = require('react-app-rewired');
 
-function rewireLess (config, env, lessLoaderOptions = {}) {
-  const lessExtension = /\.less$/;
+function createRewireLess(lessLoaderOptions = {}) {
+  return function(config, env) {
+    const lessExtension = /\.less$/;
 
-  const fileLoader = getLoader(
-    config.module.rules, rule => rule.loader && typeof rule.loader === 'string' && rule.loader.endsWith(`file-loader${path.sep}index.js`)
-  );
-  fileLoader.exclude.push(lessExtension);
+    const fileLoader = getLoader(
+      config.module.rules,
+      rule =>
+        rule.loader &&
+        typeof rule.loader === 'string' &&
+        rule.loader.endsWith(`file-loader${path.sep}index.js`)
+    );
+    fileLoader.exclude.push(lessExtension);
 
-  const cssRules = getLoader(
-    config.module.rules, rule => String(rule.test) === String(/\.css$/)
-  );
+    const cssRules = getLoader(
+      config.module.rules,
+      rule => String(rule.test) === String(/\.css$/)
+    );
 
-  let lessRules;
-  if (env === 'production') {
-    lessRules = {
-      test: lessExtension,
-      loader: [
-        // TODO: originally this part is wrapper in extract-text-webpack-plugin
-        //       which we cannot do, so some things like relative publicPath
-        //       will not work.
-        //       https://github.com/timarney/react-app-rewired/issues/33
-        ...cssRules.loader,
-        { loader: 'less-loader', options: lessLoaderOptions }
-      ]
-    };
-  } else {
-    lessRules = {
-      test: lessExtension,
-      use: [
-        ...cssRules.use,
-        { loader: 'less-loader', options: lessLoaderOptions }
-      ]
-    };
-  }
+    let lessRules;
+    if (env === 'production') {
+      lessRules = {
+        test: lessExtension,
+        loader: [
+          // TODO: originally this part is wrapper in extract-text-webpack-plugin
+          //       which we cannot do, so some things like relative publicPath
+          //       will not work.
+          //       https://github.com/timarney/react-app-rewired/issues/33
+          ...cssRules.loader,
+          { loader: 'less-loader', options: lessLoaderOptions }
+        ]
+      };
+    } else {
+      lessRules = {
+        test: lessExtension,
+        use: [
+          ...cssRules.use,
+          { loader: 'less-loader', options: lessLoaderOptions }
+        ]
+      };
+    }
 
-  config.module.rules.push(lessRules);
+    config.module.rules.push(lessRules);
 
-  return config;
+    return config;
+  };
 }
+
+const rewireLess = createRewireLess();
+
+rewireLess.withLoaderOptions = createRewireLess;
 
 module.exports = rewireLess;

--- a/packages/react-app-rewired/index.js
+++ b/packages/react-app-rewired/index.js
@@ -2,15 +2,15 @@ const path = require('path');
 
 const babelLoaderMatcher = function(rule) {
   return rule.loader && rule.loader.indexOf(`babel-loader${path.sep}`) != -1;
-}
+};
 
 const getLoader = function(rules, matcher) {
   var loader;
 
   rules.some(rule => {
-    return loader = matcher(rule)
+    return (loader = matcher(rule)
       ? rule
-      : getLoader(rule.use || rule.oneOf || [], matcher);
+      : getLoader(rule.use || rule.oneOf || [], matcher));
   });
 
   return loader;
@@ -18,19 +18,31 @@ const getLoader = function(rules, matcher) {
 
 const getBabelLoader = function(rules) {
   return getLoader(rules, babelLoaderMatcher);
-}
+};
 
 const injectBabelPlugin = function(pluginName, config) {
   const loader = getBabelLoader(config.module.rules);
   if (!loader) {
-    console.log("babel-loader not found");
+    console.log('babel-loader not found');
     return config;
   }
-  
+  const plugins = Array.isArray(pluginName) ? pluginName : [pluginName];
   // Older versions of webpack have `plugins` on `loader.query` instead of `loader.options`.
   const options = loader.options || loader.query;
-  options.plugins = [pluginName].concat(options.plugins || []);
+  options.plugins = plugins.concat(options.plugins || []);
   return config;
+};
+
+const compose = function(...funcs) {
+  if (funcs.length === 0) {
+    return config => config;
+  }
+
+  if (funcs.length === 1) {
+    return funcs[0];
+  }
+
+  return funcs.reduce((a, b) => (config, env) => a(b(config, env), env));
 };
 
 module.exports = { getLoader, getBabelLoader, injectBabelPlugin };

--- a/packages/react-app-rewired/index.js
+++ b/packages/react-app-rewired/index.js
@@ -45,4 +45,4 @@ const compose = function(...funcs) {
   return funcs.reduce((a, b) => (config, env) => a(b(config, env), env));
 };
 
-module.exports = { getLoader, getBabelLoader, injectBabelPlugin };
+module.exports = { getLoader, getBabelLoader, injectBabelPlugin, compose };

--- a/packages/react-app-rewired/index.js
+++ b/packages/react-app-rewired/index.js
@@ -26,10 +26,9 @@ const injectBabelPlugin = function(pluginName, config) {
     console.log('babel-loader not found');
     return config;
   }
-  const plugins = Array.isArray(pluginName) ? pluginName : [pluginName];
   // Older versions of webpack have `plugins` on `loader.query` instead of `loader.options`.
   const options = loader.options || loader.query;
-  options.plugins = plugins.concat(options.plugins || []);
+  options.plugins =  [pluginName].concat(options.plugins || []);
   return config;
 };
 


### PR DESCRIPTION
1. ~~`InjectBabelPlugin` should Support Array<String>~~ 

2. Add `compose` like redux, now the `config-overrides.js`  like this:
```javascript
const rewireMobX = require('react-app-rewire-mobx');
const rewirePreact = require('react-app-rewire-preact');
...
module.exports = compose(
  rewireMobX,
  rewirePreact,
  rewireLess,
  rewireOptimize,
  rewireHotLoader
 ....
);
```
if you want to add some custom you can write like this 
```javascript
module.exports = function overrides(config, env) {
   const applyedRewires = compose(
      rewireMobX,
      rewirePreact,
      rewireLess,
      rewireOptimize,
      rewireHotLoader
      ....
   )
   // do something you want to do
   return applyedRewires(config, env);
}
```

So we do not have to write too much code like `config = rewireSomething(config, env)`