### PR TITLE
Allow eslint config options overrides

### DIFF
--- a/packages/react-app-rewire-eslint/index.js
+++ b/packages/react-app-rewire-eslint/index.js
@@ -11,7 +11,7 @@ function getEslintOptions(rules) {
   return getLoader(rules, matcher).options;
 }
 
-function rewireEslint(config, env) {
+function rewireEslint(config, env, override = f => f) {
   // if `react-scripts` version < 1.0.0
   // **eslint options** is in `config`
   const oldOptions = config.eslint;
@@ -23,6 +23,9 @@ function rewireEslint(config, env) {
   const options = oldOptions || newOptions;
   options.useEslintrc = true;
   options.ignore = true;
+
+  override(options);
+
   return config;
 }
 


### PR DESCRIPTION
The specific use-case I'm trying to solve is a way to override the baseConfig setting. I don't want to get errors for linter settings that CRA specifies that I don't.

It would also be reasonable to set that property directly, but that would be a semi-breaking change. This seemed like the most generic way of allowing eslint customizations.