### PR TITLE
Fix file-loader exclusion in react-app-rewire-less

### DIFF
--- a/packages/react-app-rewire-less/index.js
+++ b/packages/react-app-rewire-less/index.js
@@ -10,7 +10,7 @@ function createRewireLess(lessLoaderOptions = {}) {
       rule =>
         rule.loader &&
         typeof rule.loader === 'string' &&
-        rule.loader.endsWith(`file-loader${path.sep}index.js`)
+        rule.loader.indexOf(`${path.sep}file-loader${path.sep}`) !== -1,
     );
     fileLoader.exclude.push(lessExtension);
 


### PR DESCRIPTION
Critical fix for react-app-rewire-less

In new version of react-scripts endsWith cant be used because loader sometimes is "file-loader/dist/cjs.js" 

This change is backwards compatible. 