### PR TITLE
put less-loader in correct position

### DIFF
--- a/packages/react-app-rewire-less/index.js
+++ b/packages/react-app-rewire-less/index.js
@@ -1,5 +1,5 @@
-const path = require('path');
-const { getLoader } = require('react-app-rewired');
+const path = require("path");
+const { getLoader } = require("react-app-rewired");
 
 function createRewireLess(lessLoaderOptions = {}) {
   return function(config, env) {
@@ -9,8 +9,8 @@ function createRewireLess(lessLoaderOptions = {}) {
       config.module.rules,
       rule =>
         rule.loader &&
-        typeof rule.loader === 'string' &&
-        rule.loader.indexOf(`${path.sep}file-loader${path.sep}`) !== -1,
+        typeof rule.loader === "string" &&
+        rule.loader.indexOf(`${path.sep}file-loader${path.sep}`) !== -1
     );
     fileLoader.exclude.push(lessExtension);
 
@@ -20,7 +20,7 @@ function createRewireLess(lessLoaderOptions = {}) {
     );
 
     let lessRules;
-    if (env === 'production') {
+    if (env === "production") {
       lessRules = {
         test: lessExtension,
         loader: [
@@ -29,7 +29,7 @@ function createRewireLess(lessLoaderOptions = {}) {
           //       will not work.
           //       https://github.com/timarney/react-app-rewired/issues/33
           ...cssRules.loader,
-          { loader: 'less-loader', options: lessLoaderOptions }
+          { loader: "less-loader", options: lessLoaderOptions }
         ]
       };
     } else {
@@ -37,12 +37,12 @@ function createRewireLess(lessLoaderOptions = {}) {
         test: lessExtension,
         use: [
           ...cssRules.use,
-          { loader: 'less-loader', options: lessLoaderOptions }
+          { loader: "less-loader", options: lessLoaderOptions }
         ]
       };
     }
 
-    config.module.rules.push(lessRules);
+    config.module.rules[1].oneOf.unshift(lessRules);
 
     return config;
   };


### PR DESCRIPTION
Okey not sure if I like this put according to the source
`https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/config/webpack.config.prod.js`
`https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/config/webpack.config.dev.js`

new rules should be put before file loader. This change fixes that that means it will also make assumptions of the real config. Another way would be to put it after eslint and before oneOf.

What do you think? Not even sure why they document that it needs to be before file loader, given that it actually works as it is today.