### PR TITLE
Add react-app-rewire-polished

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ module.exports = createRewire;
 * [react-app-rewire-emotion](https://github.com/osdevisnot/react-app-rewire-contrib/tree/master/packages/react-app-rewire-emotion) by [@osdevisnot](https://github.com/osdevisnot)
 * [react-app-rewire-lodash](https://github.com/osdevisnot/react-app-rewire-contrib/tree/master/packages/react-app-rewire-lodash) by [@osdevisnot](https://github.com/osdevisnot)
 * [react-app-rewire-styled-components](https://github.com/withspectrum/react-app-rewire-styled-components) by [@mxstbr](https://github.com/mxstbr)
+* [react-app-rewire-polished](https://github.com/rawrmonstar/react-app-rewire-polished) by [@rawrmonstar](https://github.com/rawrmonstar)
 
 ## Webpack plugins
 


### PR DESCRIPTION
I just created a tiny rewire for [babel-plugin-polished](https://github.com/styled-components/babel-plugin-polished) so I thought it might be useful to add it to the community maintained rewires section of the readme.