### PR TITLE
Fix script path in monorepo jest

### DIFF
--- a/packages/react-app-rewired/scripts/utils/paths.js
+++ b/packages/react-app-rewired/scripts/utils/paths.js
@@ -10,12 +10,16 @@ if (cs_index > -1 && cs_index + 1 <= process.argv.length) {
 }
 
 const scriptVersion = custom_scripts || 'react-scripts';
+const modulePath = path.join(
+  require.resolve(`${scriptVersion}/package.json`),
+  '..'
+);
 const projectDir = path.resolve(fs.realpathSync(process.cwd()));
 
-const paths = require(scriptVersion + '/config/paths');
+const paths = require(modulePath + '/config/paths');
 
 module.exports = Object.assign({
-  scriptVersion: scriptVersion,
+  scriptVersion: modulePath,
   configOverrides: projectDir + '/config-overrides',
   customScriptsIndex: (custom_scripts ? cs_index : -1)
 }, paths);


### PR DESCRIPTION
I [confirmed](https://github.com/facebookincubator/create-react-app/issues/3410#issuecomment-342020293) that this is the proper way to locate react scripts. This fixes [the issue](https://github.com/timarney/react-app-rewired/issues/117) I was having with the test runner.