### PR TITLE
Fixes issue 136.

### DIFF
--- a/packages/react-app-rewire-less/index.js
+++ b/packages/react-app-rewire-less/index.js
@@ -42,7 +42,14 @@ function createRewireLess(lessLoaderOptions = {}) {
       };
     }
 
-    config.module.rules[1].oneOf.unshift(lessRules);
+    const oneOfRule = config.module.rules.find((rule) => rule.oneOf !== undefined);
+    if (oneOfRule) {
+      oneOfRule.oneOf.unshift(lessRules);
+    }
+    else {
+      // Fallback to previous behaviour of adding to the end of the rules list.
+      config.module.rules.push(lessRules);
+    }
 
     return config;
   };


### PR DESCRIPTION
The current way of searching for the oneOf rule breaks for anyone using the custom-scripts options if the scripts they are using do not have the exact layout that react-scripts does.

For example, react-scripts-ts has pre rules for both ts and for js before defining the oneOf rules, which means that it is in location rules[2] not rules[1].

This change searches for an actual rule defining the oneOf condition, and falls back to the previous behaviour if one is not found.

Fixes issue #136.