### PR TITLE
Add react-app-rewire-glamorous-displayname

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ module.exports = createRewire;
 * [react-app-rewire-styled-components](https://github.com/withspectrum/react-app-rewire-styled-components) by [@mxstbr](https://github.com/mxstbr)
 * [react-app-rewire-polished](https://github.com/rawrmonstar/react-app-rewire-polished) by [@rawrmonstar](https://github.com/rawrmonstar)
 * [react-app-rewire-idx](https://github.com/viktorivarsson/react-app-rewire-idx) by [@viktorivarsson](https://github.com/viktorivarsson)
+* [react-app-rewire-glamorous-displayname](https://github.com/CarlRosell/react-app-rewire-glamorous-displayname) by [@CarlRosell](https://github.com/CarlRosell)
 
 ## Webpack plugins
 


### PR DESCRIPTION
I've added a rewire for [babel-plugin-glamorous-displayname](https://github.com/bernard-lin/babel-plugin-glamorous-displayname). I added it into the community babel rewires of the readme in case anyone else is looking for it.