### PR TITLE
Fixes issue #145

### DIFF
--- a/packages/react-app-rewire-eslint/index.js
+++ b/packages/react-app-rewire-eslint/index.js
@@ -1,13 +1,11 @@
 const path = require('path');
-const { getLoader } = require('react-app-rewired');
+const { getLoader, loaderNameMatches } = require('react-app-rewired');
 
 // this is the path of eslint-loader `index.js`
-const ESLINT_PATH = `eslint-loader${path.sep}index.js`;
+const ESLINT_PATH = 'eslint-loader';
 
 function getEslintOptions(rules) {
-  const matcher = (rule) => rule.loader 
-    && typeof rule.loader === 'string' 
-    && rule.loader.endsWith(ESLINT_PATH);
+  const matcher = (rule) => loaderNameMatches(rule, ESLINT_PATH);
   return getLoader(rules, matcher).options;
 }
 

--- a/packages/react-app-rewire-less/index.js
+++ b/packages/react-app-rewire-less/index.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { getLoader } = require("react-app-rewired");
+const { getLoader, loaderNameMatches } = require("react-app-rewired");
 
 function createRewireLess(lessLoaderOptions = {}) {
   return function(config, env) {
@@ -7,11 +7,7 @@ function createRewireLess(lessLoaderOptions = {}) {
 
     const fileLoader = getLoader(
       config.module.rules,
-      rule =>
-        rule.loader &&
-        typeof rule.loader === 'string' &&
-        (rule.loader.indexOf(`${path.sep}file-loader${path.sep}`) !== -1 ||
-        rule.loader.indexOf(`@file-loader${path.sep}`) !== -1)
+      rule => loaderNameMatches(rule, 'file-loader')
     );
     fileLoader.exclude.push(lessExtension);
 

--- a/packages/react-app-rewire-less/index.js
+++ b/packages/react-app-rewire-less/index.js
@@ -10,7 +10,8 @@ function createRewireLess(lessLoaderOptions = {}) {
       rule =>
         rule.loader &&
         typeof rule.loader === 'string' &&
-        rule.loader.indexOf(`${path.sep}file-loader${path.sep}`) !== -1
+        (rule.loader.indexOf(`${path.sep}file-loader${path.sep}`) !== -1 ||
+        rule.loader.indexOf(`@file-loader${path.sep}`) !== -1)
     );
     fileLoader.exclude.push(lessExtension);
 

--- a/packages/react-app-rewired/index.js
+++ b/packages/react-app-rewired/index.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 const babelLoaderMatcher = function(rule) {
-  return rule.loader && rule.loader.indexOf(`babel-loader${path.sep}`) != -1;
+  return loaderNameMatches(rule, 'babel-loader');
 };
 
 const getLoader = function(rules, matcher) {
@@ -15,6 +15,12 @@ const getLoader = function(rules, matcher) {
 
   return loader;
 };
+
+const loaderNameMatches = function(rule, loader_name) {
+  return rule && rule.loader && typeof rule.loader === 'string' &&
+    (rule.loader.indexOf(`${path.sep}${loader_name}${path.sep}`) !== -1 ||
+    rule.loader.indexOf(`@${loader_name}${path.sep}`) !== -1);
+}
 
 const getBabelLoader = function(rules) {
   return getLoader(rules, babelLoaderMatcher);
@@ -44,4 +50,4 @@ const compose = function(...funcs) {
   return funcs.reduce((a, b) => (config, env) => a(b(config, env), env));
 };
 
-module.exports = { getLoader, getBabelLoader, injectBabelPlugin, compose };
+module.exports = { getLoader, loaderNameMatches, getBabelLoader, injectBabelPlugin, compose };


### PR DESCRIPTION
This alters the search for file-loader to include either file-loader as a directory name, or file-loader being referred to by version number in the directory name.

On some systems, it is referred to in a format like: `"loader": "E:\\WEB\\projects\\antd-spa\\node_modules\\_file-loader@0.11.2@file-loader\\index.js"`. In those cases, the existing search failed to be able to find the file-loader rule.