### PR TITLE
Make it easier to override devserver configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,15 +192,7 @@ module.exports = {
   // The function to use to create a webpack dev server configuration when running the development
   // server with 'npm run start' or 'yarn start'.
   // Example: set the dev server to use a specific certificate in https.
-  devServer: function(configFunction) {
-    // Return the replacement function for create-react-app to use to generate the Webpack
-    // Development Server config. "configFunction" is the function that would normally have
-    // been used to generate the Webpack Development server config - you can use it to create
-    // a starting configuration to then modify instead of having to create a config from scratch.
-    return function(proxy, allowedHost) {
-      // Create the default config by calling configFunction with the proxy/allowedHost parameters
-      const config = configFunction(proxy, allowedHost);
-
+  devServer: function(config) {
       // Change the https certificate options to match your certificate, using the .env file to
       // set the file paths & passphrase.
       const fs = require('fs');

--- a/packages/react-app-rewired/config-overrides.js
+++ b/packages/react-app-rewired/config-overrides.js
@@ -6,9 +6,7 @@ const webpack = typeof override === 'function'
   : override.webpack || ((config, env) => config);
 
 const devserver = override.devserver
-  || ((configFunction) =>
-    (proxy, allowedHost) =>
-      configFunction(proxy, allowedHost));
+  || ((config) => config);
 
 const jest = override.jest || ((config) => config);
 

--- a/packages/react-app-rewired/config-overrides.js
+++ b/packages/react-app-rewired/config-overrides.js
@@ -5,7 +5,7 @@ const webpack = typeof override === 'function'
   ? override
   : override.webpack || ((config, env) => config);
 
-const devserver = override.devserver
+const devServer = override.devServer
   || ((config) => config);
 
 const jest = override.jest || ((config) => config);
@@ -13,6 +13,6 @@ const jest = override.jest || ((config) => config);
 // normalized overrides functions
 module.exports = {
   webpack,
-  devserver,
+  devServer,
   jest
 };

--- a/packages/react-app-rewired/scripts/start.js
+++ b/packages/react-app-rewired/scripts/start.js
@@ -9,11 +9,15 @@ const devserverConfigPath = paths.scriptVersion + "/config/webpackDevServer.conf
 require(paths.scriptVersion + '/config/env');
 // load original configs
 const webpackConfig = require(webpackConfigPath);
-const devserverConfig = require(devserverConfigPath);
+const devserverConfigFn = require(devserverConfigPath);
 // override config in memory
 require.cache[require.resolve(webpackConfigPath)].exports =
   overrides.webpack(webpackConfig, process.env.NODE_ENV);
-require.cache[require.resolve(devserverConfigPath)].exports =
-  overrides.devserver(devserverConfig, process.env.NODE_ENV);
+
+require.cache[require.resolve(devserverConfigPath)].exports = (proxy, allowedHost) => {
+  config = devserverConfigFn(proxy, allowedHost);
+  return overrides.devserver(config);
+}
+
 // run original script
 require(paths.scriptVersion + "/scripts/start");

--- a/packages/react-app-rewired/scripts/start.js
+++ b/packages/react-app-rewired/scripts/start.js
@@ -3,20 +3,20 @@ process.env.NODE_ENV = process.env.NODE_ENV || "development";
 const paths = require("./utils/paths");
 const overrides = require('../config-overrides');
 const webpackConfigPath = paths.scriptVersion + "/config/webpack.config.dev";
-const devserverConfigPath = paths.scriptVersion + "/config/webpackDevServer.config.js";
+const devServerConfigPath = paths.scriptVersion + "/config/webpackDevServer.config.js";
 
 // load environment variables from .env files
 require(paths.scriptVersion + '/config/env');
 // load original configs
 const webpackConfig = require(webpackConfigPath);
-const devserverConfigFn = require(devserverConfigPath);
+const devServerConfigFn = require(devServerConfigPath);
 // override config in memory
 require.cache[require.resolve(webpackConfigPath)].exports =
   overrides.webpack(webpackConfig, process.env.NODE_ENV);
 
-require.cache[require.resolve(devserverConfigPath)].exports = (proxy, allowedHost) => {
-  config = devserverConfigFn(proxy, allowedHost);
-  return overrides.devserver(config);
+require.cache[require.resolve(devServerConfigPath)].exports = (proxy, allowedHost) => {
+  config = devServerConfigFn(proxy, allowedHost);
+  return overrides.devServer(config);
 }
 
 // run original script


### PR DESCRIPTION
Reduce some fixed code, when overwrite `devServer` configuration

before
```javascript
devServer: (configFn) => (proxy, allowedHost) => {
   //  It's disgusting to write these fixed code every time, 
   const config = configFn(proxy, allowedHost);
   //  Something override for config
  return config;
}
```
now
```javascript
devServer: (config)=> {
   //  Something override for config
  return config;
}
```