### PR TITLE
Adding babel-plugin-import rewire to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ If you have several custom overrides using a directory allows you to be able to 
 * [react-app-rewire-polished](https://github.com/rawrmonstar/react-app-rewire-polished) by [@rawrmonstar](https://github.com/rawrmonstar)
 * [react-app-rewire-idx](https://github.com/viktorivarsson/react-app-rewire-idx) by [@viktorivarsson](https://github.com/viktorivarsson)
 * [react-app-rewire-glamorous-displayname](https://github.com/CarlRosell/react-app-rewire-glamorous-displayname) by [@CarlRosell](https://github.com/CarlRosell)
+* [react-app-rewire-import](https://github.com/brianveltman/react-app-rewire-import) by [@brianveltman](https://github.com/brianveltman)
 
 ## Webpack plugins
 


### PR DESCRIPTION
Created a rewire for babel-plugin-import which modularly imports javascript and css.

[@ant-design/babel-plugin-import](https://github.com/ant-design/babel-plugin-import)