### PR TITLE
add support for less modules in react-scripts 2.0

### DIFF
--- a/packages/react-app-rewire-less/README.md
+++ b/packages/react-app-rewire-less/README.md
@@ -1,4 +1,4 @@
-# Rewire create-react-app to use LESS!
+# Rewire create-react-app to use LESS and LESS modules!
 
 You might not need this rewire, Create React App added guide about how to add Less support to CRA without the need of ejecting. See [Adding a CSS Preprocessor](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-a-css-preprocessor-sass-less-etc) section of CRA guide. Also note, that their solution is based on compiling Less without using Webpack.
 
@@ -19,7 +19,48 @@ const rewireLess = require('react-app-rewire-less');
 module.exports = function override(config, env) {
   config = rewireLess(config, env);
   // with loaderOptions
-  // config = rewireLess.withLoaderOptions(someLoaderOptions)(config, env);
+  // config = rewireLess.withLoaderOptions({
+  //  modifyVars: {
+  //     "@primary-color": "#1890ff",
+  //    },
+  //})(config, env);
   return config;
+}
+```
+
+In your React application:
+
+```jsx harmony
+// src/App.js
+
+import React from 'react';
+import './index.less';
+import styles from './App.module.less';
+
+export default ({text}) => (
+    <div className={styles.app}>{text}</div>
+)
+```
+
+Regular less files are loaded as global styles
+
+```less
+// src/index.less
+body {
+  font-family: "Comic Sans MS",
+}
+```
+
+Module less files are loaded as CSS modules
+
+```less
+// src/App.module.less
+
+.app {
+  color: aqua;
+
+  &:hover {
+    color: lawngreen;
+  }
 }
 ```

--- a/packages/react-app-rewire-less/index.js
+++ b/packages/react-app-rewire-less/index.js
@@ -1,51 +1,68 @@
 const path = require("path");
 const { getLoader, loaderNameMatches } = require("react-app-rewired");
 
+const lessExtension = /\.less$/;
+const lessModuleExtension = /\.module.less$/;
+
 function createRewireLess(lessLoaderOptions = {}) {
   return function(config, env) {
-    const lessExtension = /\.less$/;
-
-    const fileLoader = getLoader(
-      config.module.rules,
-      rule => loaderNameMatches(rule, 'file-loader')
-    );
+    // Exclude all less files (including module files) from file-loader
+    const fileLoader = getLoader(config.module.rules, rule => {
+      return loaderNameMatches(rule, "file-loader") && rule.exclude;
+    });
     fileLoader.exclude.push(lessExtension);
 
-    const cssRules = getLoader(
-      config.module.rules,
-      rule => String(rule.test) === String(/\.css$/)
+    const createRule = (rule, cssRules) => {
+      if (env === "production") {
+        return {
+          ...rule,
+          loader: [
+            ...cssRules.loader,
+            { loader: "less-loader", options: lessLoaderOptions },
+          ],
+        };
+      } else {
+        return {
+          ...rule,
+          use: [
+            ...cssRules.use,
+            { loader: "less-loader", options: lessLoaderOptions },
+          ],
+        };
+      }
+    };
+
+    const lessRules = createRule(
+      {
+        test: lessExtension,
+        exclude: lessModuleExtension,
+      },
+      // Get a copy of the CSS loader
+      getLoader(
+        config.module.rules,
+        rule => String(rule.test) === String(/\.css$/),
+      ),
     );
 
-    let lessRules;
-    if (env === "production") {
-      lessRules = {
-        test: lessExtension,
-        loader: [
-          // TODO: originally this part is wrapper in extract-text-webpack-plugin
-          //       which we cannot do, so some things like relative publicPath
-          //       will not work.
-          //       https://github.com/timarney/react-app-rewired/issues/33
-          ...cssRules.loader,
-          { loader: "less-loader", options: lessLoaderOptions }
-        ]
-      };
-    } else {
-      lessRules = {
-        test: lessExtension,
-        use: [
-          ...cssRules.use,
-          { loader: "less-loader", options: lessLoaderOptions }
-        ]
-      };
-    }
+    const lessModuleRules = createRule(
+      { test: lessModuleExtension },
+      // Get a copy of the CSS module loader
+      getLoader(
+        config.module.rules,
+        rule => String(rule.test) === String(/\.module\.css$/),
+      ),
+    );
 
-    const oneOfRule = config.module.rules.find((rule) => rule.oneOf !== undefined);
+    const oneOfRule = config.module.rules.find(
+      rule => rule.oneOf !== undefined,
+    );
     if (oneOfRule) {
       oneOfRule.oneOf.unshift(lessRules);
-    }
-    else {
+      oneOfRule.oneOf.unshift(lessModuleRules);
+    } else {
       // Fallback to previous behaviour of adding to the end of the rules list.
       config.module.rules.push(lessRules);
+      config.module.rules.push(lessModuleRules);
     }
 
     return config;

--- a/packages/react-app-rewire-less/package.json
+++ b/packages/react-app-rewire-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-app-rewire-less",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -12,6 +12,6 @@
     "less-loader": "^4.0.5"
   },
   "peerDependencies": {
-    "react-app-rewired": "^1.2.1"
+    "react-app-rewired": "^2.0.0"
   }
 }

--- a/packages/react-app-rewired/package.json
+++ b/packages/react-app-rewired/package.json
@@ -1,13 +1,13 @@
 {
   "name": "react-app-rewired",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Tweak the create-react-app webpack config(s) without using 'eject' and without creating a fork of the react-scripts",
   "private": false,
   "bin": {
     "react-app-rewired": "./bin/index.js"
   },
   "peerDependencies": {
-    "react-scripts": "^1.0.14"
+    "react-scripts": "^2.0.0"
   },
   "dependencies": {
     "cross-spawn": "^5.1.0",


### PR DESCRIPTION
react-scripts 2.0 will support css modules with `.module.css` extension. naturally the less rewire should support less modules with the extension `.module.less`