### PR TITLE
Update react-styleguidist.md

### DIFF
--- a/packages/react-app-rewired/examples/react-styleguidist.md
+++ b/packages/react-app-rewired/examples/react-styleguidist.md
@@ -31,7 +31,10 @@ process.env.NODE_ENV = process.env.NODE_ENV || "development";
 const paths = require("react-app-rewired/scripts/utils/paths");
 require(paths.scriptVersion + "/config/env");
 
-const webpackConfig = paths.scriptVersion + "/config/webpack.config.dev";
+const webpackConfig = (process.env.NODE_ENV === 'production')
+    ? paths.scriptVersion + '/config/webpack.config.prod'
+    : paths.scriptVersion + '/config/webpack.config.dev';
+    
 const config = require(webpackConfig);
 const override = require(paths.configOverrides);
 const overrideFn =


### PR DESCRIPTION
Use the right config based on NODE_ENV.
E.g. when running `styleguide:build` the production config needs to be used.