### PR TITLE
Iterate rule `loader` in addition to `use` and `oneOf` when possible

### DIFF
--- a/packages/react-app-rewired/index.js
+++ b/packages/react-app-rewired/index.js
@@ -17,7 +17,7 @@ const getLoader = function(rules, matcher) {
   rules.some(rule => {
     return (loader = matcher(rule)
       ? rule
-      : getLoader(rule.use || rule.oneOf || [], matcher));
+      : getLoader(rule.use || rule.oneOf || (Array.isArray(rule.loader) && rule.loader) || [], matcher);
   });
 
   return loader;


### PR DESCRIPTION
Using react-scripts 1.1.4, a loader I needed to mess with the configuration of, `css-loader`, is nested under `"loader": [ ... ]` when building, but `"use": [ ... ]` when running the dev server.

Gist of CRA's config from the production build with relevant lines highlighted: https://gist.github.com/brentd/0f142bb23e3f145802d97b8e2668ea7f#file-webpack-js-L90-L111

This PR adds `loader` as a possible key to iterate over when matching rules.