### PR TITLE
Preact rewire: merge aliases instead of replacing

### DIFF
--- a/packages/react-app-rewire-preact/index.js
+++ b/packages/react-app-rewire-preact/index.js
@@ -1,11 +1,9 @@
 function rewirePreact(config, env) {
-  config.resolve = {
-    "alias": {
-      "react": "preact-compat",
-      "react-dom": "preact-compat",
-      "mobx-react": "mobx-preact"
-    }
-  }
+  config.resolve.alias = Object.assign(config.resolve.alias, {
+    "react": "preact-compat",
+    "react-dom": "preact-compat",
+    "mobx-react": "mobx-preact"
+  });
 
   return config;
 }


### PR DESCRIPTION
Fixes the issue described in #269 by merging the `config.resolve.alias` object with the Preact aliases.