### PR TITLE
Add react-app-rewire-css-modules-extensionless to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ If you need to change the location of your config-overrides.js you can pass a co
 * [react-app-rewire-typescript](https://github.com/lwd-technology/react-app-rewire-typescript) by [@jtheis85](https://github.com/jtheis85)
 * [react-app-rewire-typescript-babel-preset](https://github.com/strothj/react-app-rewire-typescript-babel-preset) by [@strothj](https://github.com/strothj)
 * [react-app-rewire-css-modules](https://github.com/codebandits/react-app-rewire-css-modules) by [@lnhrdt](https://github.com/lnhrdt)
+* [react-app-rewire-css-modules-extensionless](https://github.com/moxystudio/react-app-rewire-css-modules-extensionless) by [@moxystudio](https://github.com/moxystudio)
 * [react-app-rewire-less-modules](https://github.com/andriijas/react-app-rewire-less-modules) by [@andriijas](https://github.com/andriijas)
 * [react-app-rewire-stylus-modules](https://github.com/marcopeg/react-app-rewire-stylus-modules) by [@marcopeg](https://github.com/marcopeg)
 * [react-app-rewire-svg-react-loader](https://github.com/codebandits/react-app-rewire-svg-react-loader) by [@lnhrdt](https://github.com/lnhrdt)


### PR DESCRIPTION
This PR adds `react-app-rewire-css-modules-extensionless` to the list of community rewires.

The reasoning for me to do `react-app-rewire-css-modules-extensionless` instead of using `react-app-rewire-css-modules`

- Be able to import css files in `src/` without having to have `.module.css` extension
- Doesn't require sass

Thanks!