### PR TITLE
paths-overrides

### DIFF
--- a/packages/react-app-rewired/scripts/build.js
+++ b/packages/react-app-rewired/scripts/build.js
@@ -9,5 +9,11 @@ const webpackConfig = require(webpackConfigPath);
 // override config in memory
 require.cache[require.resolve(webpackConfigPath)].exports =
   overrides.webpack(webpackConfig, process.env.NODE_ENV);
+// override paths in memory
+if (paths.pathsOverrides) {
+  const pathsOverridesFn = require(paths.pathsOverrides);
+  require.cache[require.resolve(paths.scriptVersion + '/config/paths')].exports =
+    pathsOverridesFn(paths.originPaths, process.env.NODE_ENV);
+}
 // run original script
 require(paths.scriptVersion + '/scripts/build');

--- a/packages/react-app-rewired/scripts/start.js
+++ b/packages/react-app-rewired/scripts/start.js
@@ -15,5 +15,12 @@ require.cache[require.resolve(webpackConfigPath)].exports =
 require.cache[require.resolve(devServerConfigPath)].exports =
   overrides.devServer(devServerConfig, process.env.NODE_ENV);
 
+// override paths in memory
+if (paths.pathsOverrides) {
+  const pathsOverridesFn = require(paths.pathsOverrides);
+  require.cache[require.resolve(paths.scriptVersion + '/config/paths')].exports =
+    pathsOverridesFn(paths.originPaths, process.env.NODE_ENV);
+}
+
 // run original script
 require(paths.scriptVersion + "/scripts/start");

--- a/packages/react-app-rewired/scripts/test.js
+++ b/packages/react-app-rewired/scripts/test.js
@@ -29,5 +29,11 @@ require.cache[require.resolve(createJestConfigPath)].exports =
 if (paths.customScriptsIndex > -1) {
   process.argv.splice(paths.customScriptsIndex, 2);
 }
+// override paths in memory
+if (paths.pathsOverrides) {
+  const pathsOverridesFn = require(paths.pathsOverrides);
+  require.cache[require.resolve(paths.scriptVersion + '/config/paths')].exports =
+    pathsOverridesFn(paths.originPaths, process.env.NODE_ENV);
+}
 // run original script
 require(paths.scriptVersion + '/scripts/test');

--- a/packages/react-app-rewired/scripts/utils/paths.js
+++ b/packages/react-app-rewired/scripts/utils/paths.js
@@ -11,15 +11,27 @@ if (cs_index > -1 && cs_index + 1 <= process.argv.length) {
 
 //Allow custom overrides package location
 const projectDir = path.resolve(fs.realpathSync(process.cwd()));
-const customPath = require(path.resolve(projectDir, 'package.json'))['config-overrides-path'];
-var config_overrides = customPath
-  ? `${ projectDir }/${ customPath }`
+const customConfigOverridesPath = require(path.resolve(projectDir, 'package.json'))['config-overrides-path'];
+var config_overrides = customConfigOverridesPath
+  ? `${ projectDir }/${ customConfigOverridesPath }`
   : `${ projectDir }/config-overrides`;
 const co_index = process.argv.indexOf('--config-overrides');
 
 if (co_index > -1 && co_index + 1 <= process.argv.length) {
   config_overrides = path.resolve(process.argv[co_index + 1]);
   process.argv.splice(co_index, 2);
+}
+
+//Allow custom paths overrides package location
+const customPathsOverridesPath = require(path.resolve(projectDir, 'package.json'))['paths-overrides-path'];
+var paths_overrides = customPathsOverridesPath
+  ? `${ projectDir }/${ customPathsOverridesPath }`
+  : `${ projectDir }/paths-overrides`;
+const po_index = process.argv.indexOf('--paths-overrides');
+
+if (po_index > -1 && po_index + 1 <= process.argv.length) {
+  paths_overrides = path.resolve(process.argv[po_index + 1]);
+  process.argv.splice(po_index, 2);
 }
 
 const scriptVersion = custom_scripts || 'react-scripts';
@@ -33,5 +45,7 @@ const paths = require(modulePath + '/config/paths');
 module.exports = Object.assign({
   scriptVersion: modulePath,
   configOverrides: config_overrides,
-  customScriptsIndex: (custom_scripts ? cs_index : -1)
+  pathsOverrides: paths_overrides,
+  customScriptsIndex: (custom_scripts ? cs_index : -1),
+  originPaths: paths
 }, paths);


### PR DESCRIPTION
Allows to use `paths-overrides.js` the same way as `config-overrides.js`but it overrides `react-scripts/config/paths`. #308 