### PR TITLE
injectBabelPlugin compatibility with react-script@2.0.0

### DIFF
--- a/packages/react-app-rewired/index.js
+++ b/packages/react-app-rewired/index.js
@@ -8,7 +8,7 @@ const loaderNameMatches = function(rule, loader_name) {
 };
 
 const babelLoaderMatcher = function(rule) {
-  return loaderNameMatches(rule, 'babel-loader');
+  return loaderNameMatches(rule, 'babel-preset-react-app');
 };
 
 const getLoader = function(rules, matcher) {
@@ -30,7 +30,7 @@ const getBabelLoader = function(rules) {
 const injectBabelPlugin = function(pluginName, config) {
   const loader = getBabelLoader(config.module.rules);
   if (!loader) {
-    console.log('babel-loader not found');
+    console.log('babel-preset-react-app not found');
     return config;
   }
   // Older versions of webpack have `plugins` on `loader.query` instead of `loader.options`.


### PR DESCRIPTION
**Do not merge!**
I'm just leaving this as a note that react-app-rewired's `injectBabelPlugin` breaks with the latest react-script@2.0.0, released yesterday on github. I could fix it by injecting in "babel-preset-react-app" instead