### PR TITLE
Mobx cra 2

### DIFF
--- a/packages/react-app-rewire-mobx/README.md
+++ b/packages/react-app-rewire-mobx/README.md
@@ -22,5 +22,6 @@ module.exports = function override(config, env) {
 
 # Notes
 
+* By default, decorators will need to follow `export` statements vs the legacy behavior or preceeding
 * [Remove experimentalDecorators warning in VSCode](https://ihatetomatoes.net/how-to-remove-experimentaldecorators-warning-in-vscode)
 

--- a/packages/react-app-rewire-mobx/index.js
+++ b/packages/react-app-rewire-mobx/index.js
@@ -1,7 +1,10 @@
 const {injectBabelPlugin} = require('react-app-rewired');
 
 function rewireMobX(config, env) {
-  return injectBabelPlugin('transform-decorators-legacy', config);
+  return injectBabelPlugin([
+    '@babel/plugin-proposal-decorators', {
+        legacy: true,
+    }], config);
 }
 
 module.exports = rewireMobX;

--- a/packages/react-app-rewire-mobx/package.json
+++ b/packages/react-app-rewire-mobx/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "babel-plugin-transform-decorators-legacy": "1.3.4"
+    "@babel/plugin-proposal-decorators": "7.1.2"
   },
   "peerDependencies": {
     "react": ">=15.6.0 < 17",

--- a/packages/react-app-rewired/examples/configurable-overrides/custom-overides/index.js
+++ b/packages/react-app-rewired/examples/configurable-overrides/custom-overides/index.js
@@ -2,6 +2,6 @@ const { injectBabelPlugin } = require('react-app-rewired');
 
 /* config-overrides.js */
 module.exports = function override(config, env) {
-  config = injectBabelPlugin('babel-plugin-transform-decorators-legacy', config);
+  config = injectBabelPlugin('@babel/plugin-proposal-decorators', config);
   return config;
 }

--- a/packages/react-app-rewired/examples/configurable-overrides/package.json
+++ b/packages/react-app-rewired/examples/configurable-overrides/package.json
@@ -12,6 +12,6 @@
     "start": "react-app-rewired start --config-overrides ./custom-overides"
   },
   "devDependencies": {
-    "babel-plugin-transform-decorators-legacy": "^1.3.4"
+    "@babel/plugin-proposal-decorators": "7.1.2"
   }
 }

--- a/packages/react-app-rewired/scripts/utils/babelTransform.js
+++ b/packages/react-app-rewired/scripts/utils/babelTransform.js
@@ -3,9 +3,9 @@ const babelJest = require('babel-jest');
 
 const customPlugins = [];
 try {
-  const decoratorsPluginPath = require.resolve('babel-plugin-transform-decorators-legacy');
+  const decoratorsPluginPath = require.resolve('@babel/plugin-proposal-decorators');
   customPlugins.push(decoratorsPluginPath);
-  console.log('⚡ Rewired added babel-plugin-transform-decorators-legacy');
+  console.log('⚡ Rewired added @babel/plugin-proposal-decorators');
 } catch (e) {
   //do nothing plugin not found
 }


### PR DESCRIPTION
This change aims to get the "rewire mobx" functionality working for Create React App v2 apps.  This will support the newer "export before decorators" syntax that it seems the standard is drifting toward.  The "legacy" flag needed to properly transpile.

I ran this locally, but didn't see a formal "test" to run or update.  Also, I'm not sure if CRA2 changes are ready to go straight into master or if this needs to target some `@next` branch.