### PR TITLE
Update README.md to suggest craco as an alternative to react-app-rewired

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ You can try [customize-cra](https://github.com/arackaf/customize-cra)
 
 or you can try [react-scripts-rewired](https://github.com/marcopeg/create-react-app/blob/master/packages/react-scripts/README.md)
 
+or you can also try [craco](https://github.com/sharegate/craco)
+
 But remember...
 
 "Stuff can break" — Dan Abramov


### PR DESCRIPTION
Suggest craco as an alternative to react-app-rewired!

The configuration style is different but the principles are the same as react-app-rewired.