### PR TITLE
Support webpack config factory (CRA v2.1.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "7"
+  - "6"
+  - "8"
 cache:
   yarn: true

--- a/packages/react-app-rewired/package.json
+++ b/packages/react-app-rewired/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "cross-spawn": "^5.1.0",
-    "dotenv": "^4.0.0"
+    "dotenv": "^4.0.0",
+    "semver": "^5.6.0"
   },
   "repository": {
     "type": "git",

--- a/packages/react-app-rewired/scripts/start.js
+++ b/packages/react-app-rewired/scripts/start.js
@@ -1,23 +1,28 @@
-process.env.NODE_ENV = process.env.NODE_ENV || "development";
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-const paths = require("./utils/paths");
+const semver = require('semver');
+
+const { scriptVersion } = require('./utils/paths');
 const overrides = require('../config-overrides');
-const scriptPkg = require(paths.scriptVersion + "/package.json");
+const scriptPkg = require(`${scriptVersion}/package.json`);
 
-const isOldScript = !(scriptPkg && scriptPkg.version >= '2.1.2');
+// CRA 2.1.2 switched to using a webpack config factory
+// https://github.com/facebook/create-react-app/pull/5722
+// https://github.com/facebook/create-react-app/releases/tag/v2.1.2
+const isWebpackFactory = semver.gte(scriptPkg && scriptPkg.version, '2.1.2');
 
-const webpackConfigPath = paths.scriptVersion + isOldScript ? "/config/webpack.config.dev" : "/config/webpack.config";
-const devServerConfigPath = paths.scriptVersion + "/config/webpackDevServer.config.js";
-
-// load original configs
+const webpackConfigPath = `${scriptVersion}/config/webpack.config${!isWebpackFactory ? '.dev' : ''}`;
+const devServerConfigPath = `${scriptVersion}/config/webpackDevServer.config.js`;
 const webpackConfig = require(webpackConfigPath);
 const devServerConfig = require(devServerConfigPath);
+
 // override config in memory
-require.cache[require.resolve(webpackConfigPath)].exports =
-  isOldScript ? overrides.webpack(webpackConfig, process.env.NODE_ENV) : (env) => overrides.webpack(webpackConfig(env), env);
+require.cache[require.resolve(webpackConfigPath)].exports = isWebpackFactory
+  ? (env) => overrides.webpack(webpackConfig(env), env)
+  : overrides.webpack(webpackConfig, process.env.NODE_ENV);
 
 require.cache[require.resolve(devServerConfigPath)].exports =
   overrides.devServer(devServerConfig, process.env.NODE_ENV);
 
 // run original script
-require(paths.scriptVersion + "/scripts/start");
+require(`${scriptVersion}/scripts/start`);


### PR DESCRIPTION
Fixes #343. 

Builds on #344.

Ran into problems with this and had to fix it. #344 was close but didn't quite work because of [parens and ternary](https://github.com/timarney/react-app-rewired/pull/344#discussion_r244511223).

CRA uses [node >= 6](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/package.json#L8), so template strings and destructuring should be ok.

There is a lot of overlap between `scripts/start` and `scripts/build`. I thought about merging them, but figured best to keep it simple.



