### PR TITLE
Implementing Paths Override

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,13 @@ module.exports = {
 
       // Return your customised Webpack Development Server config.
       return config;
-    }
-  }
+    },
+  },
+  // The paths config to use when compiling your react app for development or production.
+  paths: function(paths, env) {
+    // ...add your paths config
+    return paths;
+  },
 }
 ```
 
@@ -174,7 +179,10 @@ Instead of this, create-react-app expects to be able to call a function to gener
 
 React-app-rewired provides the ability to override this function through use of the `devServer` field in the module.exports object in `config-overrides.js`. It provides the devServer function a single parameter containing the default create-react-app function that is normally used to generate the dev server config (it cannot provide a generated version of the configuration because react-scripts is calling the generation function directly). React-app-rewired needs to receive as a return value a _replacement function_ for create-react-app to then use to generate the Development Server configuration (i.e. the return value should be a new function that takes the two parameters for proxy and allowedHost and itself returns a Webpack Development Server configuration). The original react-scripts function is passed into the `config-overrides.js` devServer function so that you are able to easily call this yourself to generate your initial devServer configuration based on what the defaults used by create-react-app are.
 
-#### 4) Provide rewired webpack config for 3rd party tools
+#### 4) Paths configuration - Development & Production
+The `paths` field is used to provide overrides for the `create-react-app` paths passed into webpack.
+
+#### 5) Provide rewired webpack config for 3rd party tools
 Some third party tools, like [`react-cosmos`](https://github.com/react-cosmos/react-cosmos) relies on your webpack config.
 You can create `webpack.config.js` file and export rewired config using following snippet:
 ```js

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Instead of this, create-react-app expects to be able to call a function to gener
 React-app-rewired provides the ability to override this function through use of the `devServer` field in the module.exports object in `config-overrides.js`. It provides the devServer function a single parameter containing the default create-react-app function that is normally used to generate the dev server config (it cannot provide a generated version of the configuration because react-scripts is calling the generation function directly). React-app-rewired needs to receive as a return value a _replacement function_ for create-react-app to then use to generate the Development Server configuration (i.e. the return value should be a new function that takes the two parameters for proxy and allowedHost and itself returns a Webpack Development Server configuration). The original react-scripts function is passed into the `config-overrides.js` devServer function so that you are able to easily call this yourself to generate your initial devServer configuration based on what the defaults used by create-react-app are.
 
 #### 4) Paths configuration - Development & Production
-The `paths` field is used to provide overrides for the `create-react-app` paths passed into webpack.
+The `paths` field is used to provide overrides for the `create-react-app` paths passed into webpack and jest.
 
 #### 5) Provide rewired webpack config for 3rd party tools
 Some third party tools, like [`react-cosmos`](https://github.com/react-cosmos/react-cosmos) relies on your webpack config.

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -22,9 +22,12 @@ const devServer = override.devServer || override.devserver
 
 const jest = override.jest || ((config) => config);
 
+const pathsOverride = override.paths || ((paths, env) => paths);
+
 // normalized overrides functions
 module.exports = {
   webpack,
   devServer,
-  jest
+  jest,
+  paths: pathsOverride
 };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -18,5 +18,13 @@ const webpackConfig = require(webpackConfigPath);
 require.cache[require.resolve(webpackConfigPath)].exports = isWebpackFactory
   ? (env) => overrides.webpack(webpackConfig(env), env)
   : overrides.webpack(webpackConfig, process.env.NODE_ENV);
+
+const pathsConfigPath = `${scriptVersion}/config/paths.js`;
+const pathsConfig = require(pathsConfigPath);
+
+// override paths in memory
+require.cache[require.resolve(pathsConfigPath)].exports =
+  overrides.paths(pathsConfig, process.env.NODE_ENV);
+
 // run original script
 require(`${scriptVersion}/scripts/build`);

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -24,5 +24,12 @@ require.cache[require.resolve(webpackConfigPath)].exports = isWebpackFactory
 require.cache[require.resolve(devServerConfigPath)].exports =
   overrides.devServer(devServerConfig, process.env.NODE_ENV);
 
+const pathsConfigPath = `${scriptVersion}/config/paths.js`;
+const pathsConfig = require(pathsConfigPath);
+
+// override paths in memory
+require.cache[require.resolve(pathsConfigPath)].exports =
+  overrides.paths(pathsConfig, process.env.NODE_ENV);
+
 // run original script
 require(`${scriptVersion}/scripts/start`);

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,10 +1,16 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'test';
 
 const path = require("path");
-const paths = require("./utils/paths");
+let paths = require("./utils/paths");
 const overrides = require('../config-overrides');
 const rewireJestConfig = require("./utils/rewireJestConfig");
 const createJestConfigPath = paths.scriptVersion + "/scripts/utils/createJestConfig";
+
+const pathsConfigPath = `${paths.scriptVersion}/config/paths.js`;
+const pathsConfig = require(pathsConfigPath);
+
+// extend paths with overrides
+paths = Object.assign({}, paths, overrides.paths(pathsConfig, process.env.NODE_ENV));
 
 // hide overrides in package.json for CRA's original createJestConfig
 const packageJson = require(paths.appPackageJson);

--- a/test/react-app/config-overrides.js
+++ b/test/react-app/config-overrides.js
@@ -19,5 +19,9 @@ module.exports = {
   devServer: configFunction => (proxy, allowedHost) => {
     const config = configFunction(proxy, allowedHost);
     return config;
+  },
+
+  paths: (paths, env) => {
+    return paths;
   }
 };


### PR DESCRIPTION
This PR implements adding a `paths` property to the `config-overrides.js` used to override `create-react-app` paths config. This has been a common request and has been used in a lot of ejected react apps.

Resolves:
1) https://github.com/timarney/react-app-rewired/issues/308
2) https://github.com/timarney/react-app-rewired/issues/353

Reimplements:
1) https://github.com/timarney/react-app-rewired/pull/309