### PR TITLE
Adding Helper Deprecation Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ module.exports = function override(config, env) {
 |   +-- src
 ```
 
-**Note:** You can use one of the default rewires (see the [packages](/packages) dir) or [injectBabelPlugin](https://github.com/timarney/react-app-rewired#1-injectbabelplugin).
-
 #### 3) 'Flip' the existing calls to `react-scripts` in `npm` scripts
 ```diff
   /* package.json */

--- a/packages/react-app-rewired/index.js
+++ b/packages/react-app-rewired/index.js
@@ -1,5 +1,24 @@
 const paths = require('./scripts/utils/paths');
 
+function deprecate(helper) {
+  throw new Error(`The "${helper}" helper has been deprecated as of v2.0. You can use customize-cra plugins in replacement - https://github.com/arackaf/customize-cra#available-plugins`);
+}
+
 module.exports = {
+  getLoader: function() {
+    return deprecate('getBabelLoader');
+  },
+  loaderNameMatches: function() {
+    return deprecate('loaderNameMatches');
+  },
+  getBabelLoader: function() {
+    return deprecate('getBabelLoader');
+  },
+  injectBabelPlugin: function() {
+    return deprecate('injectBabelPlugin');
+  },
+  compose: function() {
+    return deprecate('compose');
+  },
   paths
 };


### PR DESCRIPTION
As of v2.0, helpers have been deprecated but it is not immediately clear to developers that those functions are simply `undefined` and don't work. If you miss the small tagline in the `README.md` file, you could have a lot of pain figuring out what went wrong and how to solve it.

This PR implements a deprecation error when those functions are used and guides developers to [customize-cra](https://github.com/arackaf/customize-cra#available-plugins).

Relates to:
1) https://github.com/timarney/react-app-rewired/commit/08486022685a5429ff3224367d89ba5acd79bde9
2) https://github.com/timarney/react-app-rewired/issues/348
3) A lot of examples online that still refer to these original helper functions