### PR TITLE
feat/scripts-version-via-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ require('./index.tsx');
 3. Override the `react-dev-utils/checkRequiredFiles` function to always return true (causing create-react-app to no longer try to enforce that the entry file must exist).
 
 #### 2) Custom scripts versions
-It is possible to use a custom version of the `react-scripts` package with react-app-rewired by specifying the name of the scripts package in the command line option `--scripts-version`.
+It is possible to use a custom version of the `react-scripts` package with react-app-rewired by specifying the name of the scripts package in the command line option `--scripts-version` or setting `REACT_SCRIPTS_VERSION=<...>` via the environment.
 
 A working example for using the scripts version option is:
 ```json

--- a/scripts/utils/paths.js
+++ b/scripts/utils/paths.js
@@ -2,7 +2,7 @@ var path = require('path');
 var fs = require('fs');
 
 //try to detect if user is using a custom scripts version
-var custom_scripts = false;
+var custom_scripts = process.env.REACT_SCRIPTS_VERSION || false;
 const cs_index = process.argv.indexOf('--scripts-version');
 
 if (cs_index > -1 && cs_index + 1 <= process.argv.length) {


### PR DESCRIPTION
# problem

the scripts version cannot be set outside of the cli, making overrides incompatible with _other_ CRA loading tools, like styleguidist

# solution

permit setting the scripts version through the env