### PR TITLE
Add react-app-rewire-typings-for-css-module link

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ If you need to change the location of your config-overrides.js you can pass a co
 * [react-app-rewire-yaml](https://github.com/hsz/react-app-rewire-yaml) by [@hsz](https://github.com/hsz)
 * [react-app-rewire-scss](https://github.com/aze3ma/react-app-rewire-scss) by [@aze3ma](https://github.com/aze3ma)
 * [react-app-rewire-external-svg-loader](https://github.com/moxystudio/react-app-rewire-external-svg-loader) by [@moxystudio](https://github.com/moxystudio)
+* [react-app-rewire-typings-for-css-module](https://github.com/rainx/react-app-rewire-typings-for-css-module) by [@rainx](https://github.com/rainx)
 
 ## Other
 


### PR DESCRIPTION
Use typings-for-css-module-loader for generate _.d.ts file for css module(Both _.module.css and *.modules.scss")

this rewire will use typings-for-css-module-loader instead of css-loader on react app config and along with namedExport and camelCase option with it