### PR TITLE
Update Peer Dependency to react-script 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "deps": "yarn && yarn --cwd 'test/react-app'"
   },
   "peerDependencies": {
-    "react-scripts": "^2.1.3"
+    "react-scripts": ">=2.1.3"
   },
   "dependencies": {
     "cross-spawn": "^6.0.5",
@@ -24,7 +24,7 @@
     "semver": "^5.6.0"
   },
   "devDependencies": {
-    "react-scripts": ">=2.1.3"
+    "react-scripts": "^2.1.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Sorry. Seems I updated the wrong property. Update Peer Dependency (not dev-dependency) to react-script 3.0.0
