### PR TITLE
Use available dependencies

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var spawn = require('cross-spawn');
+var spawn = require('react-dev-utils/crossSpawn');
 const args = process.argv.slice(2);
 
 const scriptIndex = args.findIndex(

--- a/bin/jest.js
+++ b/bin/jest.js
@@ -7,7 +7,7 @@
  * For more information, see https://github.com/timarney/react-app-rewired/issues/182
  */
 
-const spawn = require('cross-spawn');
+const spawn = require('react-dev-utils/crossSpawn');
 const args = process.argv.slice(2);
 
 // ignore --config param like it was never there

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "react-scripts": ">=2.1.3"
   },
   "dependencies": {
-    "cross-spawn": "^6.0.5",
-    "dotenv": "^6.2.0",
     "semver": "^5.6.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3132,11 +3132,6 @@ dotenv@6.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.0.0.tgz#24e37c041741c5f4b25324958ebbc34bca965935"
   integrity sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg==
 
-dotenv@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
-  integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
-
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"


### PR DESCRIPTION
This change removes 2 dependencies that are not needed, and brings react-app-rewired “_closer to the metal_” (further into alignment) with `create-react-app`.

---

Use `react-dev-utils/crossSpawn` over `cross-spawn`, as it is available and used in Create React App v1-3:

- v3: https://github.com/facebook/create-react-app/blob/v3.1.2/packages/react-scripts/bin/react-scripts.js#L18
- v2: https://github.com/facebook/create-react-app/blob/v2.1.8/packages/react-scripts/bin/react-scripts.js#L18
- v1: https://github.com/facebook/create-react-app/blob/v1.1.5/packages/react-scripts/bin/react-scripts.js#L11

---

Don’t depend on `dotenv` because it is not being used or is no longer being used.