### PR TITLE
fix: override defaults when merging Jest config

### DIFF
--- a/scripts/utils/rewireJestConfig.js
+++ b/scripts/utils/rewireJestConfig.js
@@ -22,7 +22,7 @@ module.exports = (config) => {
           config[key] = overrides[key].concat(config[key]);
         }
         else if(typeof overrides[key] === 'object') {
-          config[key] = Object.assign({}, overrides[key], config[key]);
+          config[key] = Object.assign({}, config[key], overrides[key]);
         }
       } else {
         config[key] = overrides[key];


### PR DESCRIPTION
This PR makes possible to override defaults for Jest config when objects are merged.

For example, [CRA has these defaults](https://github.com/facebook/create-react-app/blob/9750738/packages/react-scripts/scripts/utils/createJestConfig.js#L56-L60):

```js
    moduleNameMapper: {
      '^react-native$': 'react-native-web',
      '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
    }
```

And I need to define own mapper for css-modules, so adding override into `package.json` as per README:
```json
  "jest": {
    "moduleNameMapper": {
      "^.+\\.module\\.(css|sass|scss)$": "<rootDir>/jest-css-stub.js"
    }
  },
```

But actually mapper stays defined as `identity-obj-proxy`, although expected result would be `<rootDir>/jest-css-stub.js`.

Note, it's all good if running `react-scripts test` — the issue occurs only when run with `react-app-rewired test`.

Took awhile to figure out the root cause, but actual bug seems just like a typo, so fix is very simple.

Thank you
