### PR TITLE
Add react-app-rewire-alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ If you need to change the location of your config-overrides.js you can pass a co
 * [react-app-rewired with Inferno](packages/react-app-rewired/examples/inferno.md)
 * [react-app-rewired with react-styleguideist](packages/react-app-rewired/examples/react-styleguidist.md)
 * [react-app-rewired with react-hot-loader](https://github.com/cdharris/react-app-rewire-hot-loader) by [@cdharris](https://github.com/cdharris)
+* [react-app-rewire-alias](https://github.com/oklas/react-app-rewire-alias) by [@oklas](https://github.com/oklas)
 * [react-app-rewire-aliases](https://github.com/aze3ma/react-app-rewire-aliases) by [@aze3ma](https://github.com/aze3ma)
 * [react-app-rewire-blockstack](https://github.com/harrysolovay/react-app-rewire-blockstack) by [@harrysolovay](https://github.com/harrysolovay)
 * [ideal-rewires](https://github.com/harrysolovay/ideal-rewires) by [@harrysolovay](https://github.com/harrysolovay)

--- a/README_zh.md
+++ b/README_zh.md
@@ -325,6 +325,7 @@ React-app-rewired 会导入您的 config-overrides.js 文件而不使用 “.js�
 * [react-app-rewired with Inferno](packages/react-app-rewired/examples/inferno.md)
 * [react-app-rewired with react-styleguideist](packages/react-app-rewired/examples/react-styleguidist.md)
 * [react-app-rewired with react-hot-loader](https://github.com/cdharris/react-app-rewire-hot-loader) by [@cdharris](https://github.com/cdharris)
+* [react-app-rewire-alias](https://github.com/oklas/react-app-rewire-alias) by [@oklas](https://github.com/oklas)
 * [react-app-rewire-aliases](https://github.com/aze3ma/react-app-rewire-aliases) by [@aze3ma](https://github.com/aze3ma)
 * [react-app-rewire-blockstack](https://github.com/harrysolovay/react-app-rewire-blockstack) by [@harrysolovay](https://github.com/harrysolovay)
 * [ideal-rewires](https://github.com/harrysolovay/ideal-rewires) by [@harrysolovay](https://github.com/harrysolovay)


### PR DESCRIPTION
Hi

Currently the `create-react-app` system do not support multiple `src` directory in root dir ([6116](https://github.com/facebook/create-react-app/pull/6116), [6269](https://github.com/facebook/create-react-app/issues/6269), [5118](https://github.com/facebook/create-react-app/issues/5118)). This feature is implemented in [react-app-rewire-alias](https://github.com/oklas/react-app-rewire-alias) mentioned in this pull. Each additional `src` directory with its own name is represented as alias and may be loaded from `tsconfig.json` or `jsconfig.json`

Thanks
