### PR TITLE
Load paths config before webpack config.

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -6,6 +6,13 @@ const { scriptVersion } = require('./utils/paths');
 const overrides = require('../config-overrides');
 const scriptPkg = require(`${scriptVersion}/package.json`);
 
+const pathsConfigPath = `${scriptVersion}/config/paths.js`;
+const pathsConfig = require(pathsConfigPath);
+
+// override paths in memory
+require.cache[require.resolve(pathsConfigPath)].exports =
+  overrides.paths(pathsConfig, process.env.NODE_ENV);
+
 // CRA 2.1.2 switched to using a webpack config factory
 // https://github.com/facebook/create-react-app/pull/5722
 // https://github.com/facebook/create-react-app/releases/tag/v2.1.2
@@ -18,13 +25,6 @@ const webpackConfig = require(webpackConfigPath);
 require.cache[require.resolve(webpackConfigPath)].exports = isWebpackFactory
   ? (env) => overrides.webpack(webpackConfig(env), env)
   : overrides.webpack(webpackConfig, process.env.NODE_ENV);
-
-const pathsConfigPath = `${scriptVersion}/config/paths.js`;
-const pathsConfig = require(pathsConfigPath);
-
-// override paths in memory
-require.cache[require.resolve(pathsConfigPath)].exports =
-  overrides.paths(pathsConfig, process.env.NODE_ENV);
 
 // run original script
 require(`${scriptVersion}/scripts/build`);

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -6,6 +6,13 @@ const { scriptVersion } = require('./utils/paths');
 const overrides = require('../config-overrides');
 const scriptPkg = require(`${scriptVersion}/package.json`);
 
+const pathsConfigPath = `${scriptVersion}/config/paths.js`;
+const pathsConfig = require(pathsConfigPath);
+
+// override paths in memory
+require.cache[require.resolve(pathsConfigPath)].exports =
+  overrides.paths(pathsConfig, process.env.NODE_ENV);
+
 // CRA 2.1.2 switched to using a webpack config factory
 // https://github.com/facebook/create-react-app/pull/5722
 // https://github.com/facebook/create-react-app/releases/tag/v2.1.2
@@ -23,13 +30,6 @@ require.cache[require.resolve(webpackConfigPath)].exports = isWebpackFactory
 
 require.cache[require.resolve(devServerConfigPath)].exports =
   overrides.devServer(devServerConfig, process.env.NODE_ENV);
-
-const pathsConfigPath = `${scriptVersion}/config/paths.js`;
-const pathsConfig = require(pathsConfigPath);
-
-// override paths in memory
-require.cache[require.resolve(pathsConfigPath)].exports =
-  overrides.paths(pathsConfig, process.env.NODE_ENV);
 
 // run original script
 require(`${scriptVersion}/scripts/start`);


### PR DESCRIPTION
The paths config doesn't really work unless you load it before the webpack config, since a bunch of paths config values are used in the webpack config module, synchronously during module loadtime. You can ctrl+F for `paths.` in [this file](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/config/webpack.config.js) to see what I mean.

When I rearranged these, my code started working.