### PR TITLE
Added parameters from webpack for SSR with create-universal-react-app

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -23,7 +23,7 @@ const webpackConfig = require(webpackConfigPath);
 
 // override config in memory
 require.cache[require.resolve(webpackConfigPath)].exports = isWebpackFactory
-  ? (env) => overrides.webpack(webpackConfig(env), env)
+  ? (env, ...others) => overrides.webpack(webpackConfig(env, ...others), env, ...others)
   : overrides.webpack(webpackConfig, process.env.NODE_ENV);
 
 // run original script

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -25,7 +25,7 @@ const devServerConfig = require(devServerConfigPath);
 
 // override config in memory
 require.cache[require.resolve(webpackConfigPath)].exports = isWebpackFactory
-  ? (env) => overrides.webpack(webpackConfig(env), env)
+  ? (env, ...others) => overrides.webpack(webpackConfig(env, ...others), env, ...others)
   : overrides.webpack(webpackConfig, process.env.NODE_ENV);
 
 require.cache[require.resolve(devServerConfigPath)].exports =


### PR DESCRIPTION
If you want to use [create-universal-react-app](https://github.com/frontarm/create-universal-react-app) then you need to pass additional parameters for webpack.

You can look at it [here](https://github.com/frontarm/create-universal-react-app/blob/master/packages/react-scripts/scripts/start.js#L110).