### PR TITLE
fix:  set jest.transformIgnorePatterns in package.json overrides failed

### DIFF
--- a/scripts/utils/rewireJestConfig.js
+++ b/scripts/utils/rewireJestConfig.js
@@ -18,8 +18,17 @@ module.exports = (config) => {
       if(config[key]) {
         if(typeof overrides[key] === 'string') {
           config[key] = overrides[key];
-        } else if(Array.isArray(overrides[key])) {
-          config[key] = overrides[key].concat(config[key]);
+        } else if(Array.isArray(overrides[key])) {          
+          if (key === 'transformIgnorePatterns' && Array.isArray(config[key]) && config[key].length) {
+              const tIndex = config[key].findIndex((item) => {
+                  return item.includes('node_modules');
+              });
+              if (tIndex !== -1) {
+                  config[key].splice(tIndex, 1, `/node_modules/(?!(${jestExtLibs}))`);
+              }            
+          }else{
+              config[key] = overrides[key].concat(config[key]);
+          }
         }
         else if(typeof overrides[key] === 'object') {
           config[key] = Object.assign({}, config[key], overrides[key]);


### PR DESCRIPTION
When using the three party libraries such as lodash-es and @alifd/next, you need to exclude them from the modules that jest ignored by default, but the current version is not.

This PR is to correct the problem。

in CRA default jest Config： https://github.com/inier/create-react-app/blob/master/packages/react-scripts/scripts/utils/createJestConfig.js，at line 52：
transformIgnorePatterns: [ 
'[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$', 
...
]