### PR TITLE
fix: support `false` values in jest config override

### DIFF
--- a/scripts/utils/rewireJestConfig.js
+++ b/scripts/utils/rewireJestConfig.js
@@ -15,7 +15,7 @@ module.exports = (config) => {
   Object.keys(overrides)
     .forEach(key => {
       //We don't overwrite the default config, but add to each property if not a string
-      if(config[key]) {
+      if(key in config) {
         if(typeof overrides[key] === 'string') {
           config[key] = overrides[key];
         } else if(Array.isArray(overrides[key])) {


### PR DESCRIPTION
Right now, if for example, you try to set `resetMocks` to `false`, the option will be ignored because the condition evaluates to false.