### PR TITLE
Fix using new jsx transform in tests

### DIFF
--- a/scripts/utils/babelTransform.js
+++ b/scripts/utils/babelTransform.js
@@ -1,7 +1,27 @@
 const babelJest = require('babel-jest');
 
+const hasJsxRuntime = (() => {
+  if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
+    return false;
+  }
+
+  try {
+    require.resolve('react/jsx-runtime');
+    return true;
+  } catch (e) {
+    return false;
+  }
+})();
+
 module.exports = babelJest.createTransformer({
-  presets: [require.resolve('babel-preset-react-app')],
+  presets: [
+    [
+      require.resolve('babel-preset-react-app'),
+      {
+        runtime: hasJsxRuntime ? 'automatic' : 'classic',
+      },
+    ]
+  ],
   plugins: [],
   babelrc: true
 });


### PR DESCRIPTION
The new jsx transform is not working in tests when run through react-app-rewired (they fail with "ReferenceError: React is not defined").  Ported over this change from create-react-app: https://github.com/facebook/create-react-app/commit/2b1161b34641bb4d2f269661cd636bbcd4888406