### PR TITLE
Added check if overriden value is primitive value like number or boolean

### DIFF
--- a/scripts/utils/rewireJestConfig.js
+++ b/scripts/utils/rewireJestConfig.js
@@ -15,8 +15,8 @@ module.exports = (config) => {
   Object.keys(overrides)
     .forEach(key => {
       //We don't overwrite the default config, but add to each property if not a string
-      if(config[key]) {
-        if(typeof overrides[key] === 'string') {
+        if (config[key]) {
+        if (typeof overrides[key] === 'string' || typeof overrides[key] === 'number' || typeof overrides[key] === 'boolean') {
           config[key] = overrides[key];
         } else if(Array.isArray(overrides[key])) {
           config[key] = overrides[key].concat(config[key]);

--- a/scripts/utils/rewireJestConfig.js
+++ b/scripts/utils/rewireJestConfig.js
@@ -15,7 +15,7 @@ module.exports = (config) => {
   Object.keys(overrides)
     .forEach(key => {
       //We don't overwrite the default config, but add to each property if not a string
-      if (config[key]) {
+      if(config[key]) {
         if(typeof overrides[key] === 'string' || typeof overrides[key] === 'number' || typeof overrides[key] === 'boolean') {
           config[key] = overrides[key];
         } else if(Array.isArray(overrides[key])) {

--- a/scripts/utils/rewireJestConfig.js
+++ b/scripts/utils/rewireJestConfig.js
@@ -15,8 +15,8 @@ module.exports = (config) => {
   Object.keys(overrides)
     .forEach(key => {
       //We don't overwrite the default config, but add to each property if not a string
-        if (config[key]) {
-        if (typeof overrides[key] === 'string' || typeof overrides[key] === 'number' || typeof overrides[key] === 'boolean') {
+      if (config[key]) {
+        if(typeof overrides[key] === 'string' || typeof overrides[key] === 'number' || typeof overrides[key] === 'boolean') {
           config[key] = overrides[key];
         } else if(Array.isArray(overrides[key])) {
           config[key] = overrides[key].concat(config[key]);


### PR DESCRIPTION
This pull requests fixes issue #507. It adds support for overriding jest configuration with primitive values like number or boolean. As for now it's limited to string, arrays or objects.
