### PR TITLE
Resolve and load dependent module paths in react-scripts

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-var spawn = require('react-dev-utils/crossSpawn');
+const { dependRequire } = require('../scripts/utils/dependRequire');
+var spawn = dependRequire('react-dev-utils/crossSpawn');
 const args = process.argv.slice(2);
 
 const scriptIndex = args.findIndex(

--- a/bin/jest.js
+++ b/bin/jest.js
@@ -7,7 +7,8 @@
  * For more information, see https://github.com/timarney/react-app-rewired/issues/182
  */
 
-const spawn = require('react-dev-utils/crossSpawn');
+const { dependRequire } = require('../scripts/utils/dependRequire');
+const spawn = dependRequire('react-dev-utils/crossSpawn');
 const args = process.argv.slice(2);
 
 // ignore --config param like it was never there

--- a/scripts/utils/babelTransform.js
+++ b/scripts/utils/babelTransform.js
@@ -1,4 +1,6 @@
-const babelJest = require('babel-jest');
+const { dependRequire, dependRequireResolve } = require('./dependRequire');
+
+const babelJest = dependRequire('babel-jest');
 
 const hasJsxRuntime = (() => {
   if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
@@ -16,7 +18,7 @@ const hasJsxRuntime = (() => {
 module.exports = babelJest.createTransformer({
   presets: [
     [
-      require.resolve('babel-preset-react-app'),
+      dependRequireResolve('babel-preset-react-app'),
       {
         runtime: hasJsxRuntime ? 'automatic' : 'classic',
       },

--- a/scripts/utils/dependRequire.js
+++ b/scripts/utils/dependRequire.js
@@ -1,0 +1,9 @@
+const { scriptVersion } = require('./paths');
+
+const dependRequireResolve = (id) => require.resolve(id, { paths: [scriptVersion] });
+const dependRequire = (id) => require(dependRequireResolve(id));
+
+module.exports = {
+  dependRequireResolve,
+  dependRequire,
+};


### PR DESCRIPTION
issue #457, #388

Depending on the project, the installation location of the package on which react-scripts depends may change.
This fix resolves and loads the dependency paths of react-scripts.