### PR TITLE
minor: removed "$" shell indicators from inline code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ or any of the alternative projects and forks that aim to support 2.0:
 ##### For create-react-app 2.x with Webpack 4:
 
 ```bash
-$ npm install react-app-rewired --save-dev
+npm install react-app-rewired --save-dev
 ```
 
 ##### For create-react-app 1.x or react-scripts-ts with Webpack 3:
 
 ```bash
-$ npm install react-app-rewired@1.6.2 --save-dev
+npm install react-app-rewired@1.6.2 --save-dev
 ```
 
 #### 2) Create a `config-overrides.js` file in the root directory
@@ -100,13 +100,13 @@ There are no configuration options to rewire for the `eject` script.
 
 #### 4) Start the Dev Server
 ```bash
-$ npm start
+npm start
 ```
 
 
 #### 5) Build your app
 ```bash
-$ npm run build
+npm run build
 ```
 
 ## Extended Configuration Options


### PR DESCRIPTION
Github automatically adds the option to copy the code block to the clipboard for each code segment.
It is very inconvenient to manually remove the "$" at the start of the string once pasted into the shell.

**While the "$" looks cool on paper, its usecase is questionable.**