### PR TITLE
fix: Override paths in memory also in "test" mode

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -12,6 +12,10 @@ const pathsConfig = require(pathsConfigPath);
 // extend paths with overrides
 paths = Object.assign({}, paths, overrides.paths(pathsConfig, process.env.NODE_ENV));
 
+// override paths in memory
+require.cache[require.resolve(pathsConfigPath)].exports =
+  paths;
+
 // hide overrides in package.json for CRA's original createJestConfig
 const packageJson = require(paths.appPackageJson);
 const jestOverrides = packageJson.jest;


### PR DESCRIPTION
`react-app-rewired` provides the correct rewired paths for the jest config, but it does not override the paths config in the memory. This leads to different errors on the `react-scripts`' side, especially when using with Typescript.

This PR fixes this bug in test.js by making the overridden paths config available to `react-scripts`.