### PR TITLE
fix(dep): added peer dep to babel-jest to avoid errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "deps": "yarn && yarn --cwd 'test/react-app'"
   },
   "peerDependencies": {
+    "babel-jest": "<27.0.0",
     "react-scripts": ">=2.1.3"
   },
   "dependencies": {


### PR DESCRIPTION
Added babel jest as a peer dep , version lower than 27 because if not it will throw errors (for example with CRA5)