### PR TITLE
feat: Mock react-scripts 'config' folder

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -1,0 +1,1 @@
+module.exports = require('../overrides/paths');

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../overrides/webpack');

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,1 +1,4 @@
+// override paths in memory
+require('../overrides/paths');
+
 module.exports = require('../overrides/webpack');

--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -1,1 +1,4 @@
+// override paths in memory
+require('../overrides/paths');
+
 module.exports = require('../overrides/devServer');

--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../overrides/devServer');

--- a/overrides/devServer.js
+++ b/overrides/devServer.js
@@ -1,0 +1,11 @@
+const { scriptVersion } = require('../scripts/utils/paths');
+const overrides = require('../config-overrides');
+
+const devServerConfigPath = `${scriptVersion}/config/webpackDevServer.config.js`;
+const devServerConfig = require(devServerConfigPath);
+
+// override config in memory
+require.cache[require.resolve(devServerConfigPath)].exports =
+	overrides.devServer(devServerConfig, process.env.NODE_ENV);
+
+module.exports = require(devServerConfigPath);

--- a/overrides/jest.js
+++ b/overrides/jest.js
@@ -1,0 +1,31 @@
+const path = require("path");
+const paths = require("./paths");
+const overrides = require('../config-overrides');
+const rewireJestConfig = require("../scripts/utils/rewireJestConfig");
+const createJestConfigPath = paths.scriptVersion + "/scripts/utils/createJestConfig";
+
+// hide overrides in package.json for CRA's original createJestConfig
+const packageJson = require(paths.appPackageJson);
+const jestOverrides = packageJson.jest;
+delete packageJson.jest;
+// load original createJestConfig
+const createJestConfig = require(createJestConfigPath);
+// run original createJestConfig
+const config = createJestConfig(
+	relativePath => path.resolve(paths.appPath, "node_modules", paths.scriptVersion, relativePath),
+	path.resolve(paths.appSrc, ".."),
+	false
+);
+// restore overrides for rewireJestConfig
+packageJson.jest = jestOverrides;
+// override createJestConfig in memory
+require.cache[require.resolve(createJestConfigPath)].exports =
+	() => overrides.jest(rewireJestConfig(config));
+// Passing the --scripts-version on to the original test script can result
+// in the test script rejecting it as an invalid option. So strip it out of
+// the command line arguments before invoking the test script.
+if (paths.customScriptsIndex > -1) {
+	process.argv.splice(paths.customScriptsIndex, 2);
+}
+
+module.exports = require(createJestConfigPath);

--- a/overrides/jest.js
+++ b/overrides/jest.js
@@ -1,8 +1,8 @@
-const path = require("path");
-const paths = require("./paths");
+const path = require('path');
+const paths = require('./paths');
 const overrides = require('../config-overrides');
-const rewireJestConfig = require("../scripts/utils/rewireJestConfig");
-const createJestConfigPath = paths.scriptVersion + "/scripts/utils/createJestConfig";
+const rewireJestConfig = require('../scripts/utils/rewireJestConfig');
+const createJestConfigPath = `${paths.scriptVersion}/scripts/utils/createJestConfig`;
 
 // hide overrides in package.json for CRA's original createJestConfig
 const packageJson = require(paths.appPackageJson);
@@ -12,8 +12,8 @@ delete packageJson.jest;
 const createJestConfig = require(createJestConfigPath);
 // run original createJestConfig
 const config = createJestConfig(
-	relativePath => path.resolve(paths.appPath, "node_modules", paths.scriptVersion, relativePath),
-	path.resolve(paths.appSrc, ".."),
+	relativePath => path.resolve(paths.appPath, 'node_modules', paths.scriptVersion, relativePath),
+	path.resolve(paths.appSrc, '..'),
 	false
 );
 // restore overrides for rewireJestConfig

--- a/overrides/paths.js
+++ b/overrides/paths.js
@@ -1,11 +1,14 @@
-const { scriptVersion } = require('../scripts/utils/paths');
+const paths = require('../scripts/utils/paths');
 const overrides = require('../config-overrides');
 
-const pathsConfigPath = `${scriptVersion}/config/paths.js`;
+const pathsConfigPath = `${paths.scriptVersion}/config/paths.js`;
 const pathsConfig = require(pathsConfigPath);
+
+// extend paths with overrides
+const extendedPaths = Object.assign({}, paths, overrides.paths(pathsConfig, process.env.NODE_ENV));
 
 // override paths in memory
 require.cache[require.resolve(pathsConfigPath)].exports =
-	overrides.paths(pathsConfig, process.env.NODE_ENV);
+	extendedPaths;
 
 module.exports = require(pathsConfigPath);

--- a/overrides/paths.js
+++ b/overrides/paths.js
@@ -1,0 +1,11 @@
+const { scriptVersion } = require('../scripts/utils/paths');
+const overrides = require('../config-overrides');
+
+const pathsConfigPath = `${scriptVersion}/config/paths.js`;
+const pathsConfig = require(pathsConfigPath);
+
+// override paths in memory
+require.cache[require.resolve(pathsConfigPath)].exports =
+	overrides.paths(pathsConfig, process.env.NODE_ENV);
+
+module.exports = require(pathsConfigPath);

--- a/overrides/webpack.js
+++ b/overrides/webpack.js
@@ -1,0 +1,28 @@
+const semver = require('semver');
+
+const { scriptVersion } = require('../scripts/utils/paths');
+const overrides = require('../config-overrides');
+const scriptPkg = require(`${scriptVersion}/package.json`);
+
+const pathsConfigPath = `${scriptVersion}/config/paths.js`;
+const pathsConfig = require(pathsConfigPath);
+
+// override paths in memory
+require.cache[require.resolve(pathsConfigPath)].exports =
+	overrides.paths(pathsConfig, process.env.NODE_ENV);
+
+// CRA 2.1.2 switched to using a webpack config factory
+// https://github.com/facebook/create-react-app/pull/5722
+// https://github.com/facebook/create-react-app/releases/tag/v2.1.2
+const isWebpackFactory = semver.gte(scriptPkg && scriptPkg.version, '2.1.2');
+const webpackFactoryEnvSuffix = process.env.NODE_ENV === 'production' ? '.prod' : '.dev';
+
+const webpackConfigPath = `${scriptVersion}/config/webpack.config${!isWebpackFactory ? webpackFactoryEnvSuffix : ''}`;
+const webpackConfig = require(webpackConfigPath);
+
+// override config in memory
+require.cache[require.resolve(webpackConfigPath)].exports = isWebpackFactory
+	? (env) => overrides.webpack(webpackConfig(env), env)
+	: overrides.webpack(webpackConfig, process.env.NODE_ENV);
+
+module.exports = require(webpackConfigPath);

--- a/overrides/webpack.js
+++ b/overrides/webpack.js
@@ -4,13 +4,6 @@ const { scriptVersion } = require('../scripts/utils/paths');
 const overrides = require('../config-overrides');
 const scriptPkg = require(`${scriptVersion}/package.json`);
 
-const pathsConfigPath = `${scriptVersion}/config/paths.js`;
-const pathsConfig = require(pathsConfigPath);
-
-// override paths in memory
-require.cache[require.resolve(pathsConfigPath)].exports =
-	overrides.paths(pathsConfig, process.env.NODE_ENV);
-
 // CRA 2.1.2 switched to using a webpack config factory
 // https://github.com/facebook/create-react-app/pull/5722
 // https://github.com/facebook/create-react-app/releases/tag/v2.1.2

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "/config-overrides.js",
     "/assets",
     "/bin",
+    "/overrides",
     "/scripts"
   ]
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,30 +1,12 @@
 process.env.NODE_ENV = 'production';
 
-const semver = require('semver');
-
 const { scriptVersion } = require('./utils/paths');
-const overrides = require('../config-overrides');
-const scriptPkg = require(`${scriptVersion}/package.json`);
-
-const pathsConfigPath = `${scriptVersion}/config/paths.js`;
-const pathsConfig = require(pathsConfigPath);
 
 // override paths in memory
-require.cache[require.resolve(pathsConfigPath)].exports =
-  overrides.paths(pathsConfig, process.env.NODE_ENV);
-
-// CRA 2.1.2 switched to using a webpack config factory
-// https://github.com/facebook/create-react-app/pull/5722
-// https://github.com/facebook/create-react-app/releases/tag/v2.1.2
-const isWebpackFactory = semver.gte(scriptPkg && scriptPkg.version, '2.1.2');
-
-const webpackConfigPath = `${scriptVersion}/config/webpack.config${!isWebpackFactory ? '.prod' : ''}`;
-const webpackConfig = require(webpackConfigPath);
+require('../overrides/paths');
 
 // override config in memory
-require.cache[require.resolve(webpackConfigPath)].exports = isWebpackFactory
-  ? (env) => overrides.webpack(webpackConfig(env), env)
-  : overrides.webpack(webpackConfig, process.env.NODE_ENV);
+require('../overrides/webpack');
 
 // run original script
 require(`${scriptVersion}/scripts/build`);

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,35 +1,13 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-const semver = require('semver');
-
 const { scriptVersion } = require('./utils/paths');
-const overrides = require('../config-overrides');
-const scriptPkg = require(`${scriptVersion}/package.json`);
-
-const pathsConfigPath = `${scriptVersion}/config/paths.js`;
-const pathsConfig = require(pathsConfigPath);
 
 // override paths in memory
-require.cache[require.resolve(pathsConfigPath)].exports =
-  overrides.paths(pathsConfig, process.env.NODE_ENV);
-
-// CRA 2.1.2 switched to using a webpack config factory
-// https://github.com/facebook/create-react-app/pull/5722
-// https://github.com/facebook/create-react-app/releases/tag/v2.1.2
-const isWebpackFactory = semver.gte(scriptPkg && scriptPkg.version, '2.1.2');
-
-const webpackConfigPath = `${scriptVersion}/config/webpack.config${!isWebpackFactory ? '.dev' : ''}`;
-const devServerConfigPath = `${scriptVersion}/config/webpackDevServer.config.js`;
-const webpackConfig = require(webpackConfigPath);
-const devServerConfig = require(devServerConfigPath);
+require('../overrides/paths');
 
 // override config in memory
-require.cache[require.resolve(webpackConfigPath)].exports = isWebpackFactory
-  ? (env) => overrides.webpack(webpackConfig(env), env)
-  : overrides.webpack(webpackConfig, process.env.NODE_ENV);
-
-require.cache[require.resolve(devServerConfigPath)].exports =
-  overrides.devServer(devServerConfig, process.env.NODE_ENV);
+require('../overrides/webpack');
+require('../overrides/devServer');
 
 // run original script
 require(`${scriptVersion}/scripts/start`);

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,20 +1,13 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'test';
 
 const path = require("path");
-let paths = require("./utils/paths");
+const paths = require("./utils/paths");
 const overrides = require('../config-overrides');
 const rewireJestConfig = require("./utils/rewireJestConfig");
 const createJestConfigPath = paths.scriptVersion + "/scripts/utils/createJestConfig";
 
-const pathsConfigPath = `${paths.scriptVersion}/config/paths.js`;
-const pathsConfig = require(pathsConfigPath);
-
-// extend paths with overrides
-paths = Object.assign({}, paths, overrides.paths(pathsConfig, process.env.NODE_ENV));
-
 // override paths in memory
-require.cache[require.resolve(pathsConfigPath)].exports =
-  paths;
+require('../overrides/paths');
 
 // hide overrides in package.json for CRA's original createJestConfig
 const packageJson = require(paths.appPackageJson);

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,6 +1,6 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'test';
 
-const paths = require("./utils/paths");
+const { scriptVersion } = require("./utils/paths");
 
 // override paths in memory
 require('../overrides/paths');
@@ -9,4 +9,4 @@ require('../overrides/paths');
 require('../overrides/jest');
 
 // run original script
-require(paths.scriptVersion + '/scripts/test');
+require(scriptVersion + '/scripts/test');

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,36 +1,12 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'test';
 
-const path = require("path");
 const paths = require("./utils/paths");
-const overrides = require('../config-overrides');
-const rewireJestConfig = require("./utils/rewireJestConfig");
-const createJestConfigPath = paths.scriptVersion + "/scripts/utils/createJestConfig";
 
 // override paths in memory
 require('../overrides/paths');
 
-// hide overrides in package.json for CRA's original createJestConfig
-const packageJson = require(paths.appPackageJson);
-const jestOverrides = packageJson.jest;
-delete packageJson.jest;
-// load original createJestConfig
-const createJestConfig = require(createJestConfigPath);
-// run original createJestConfig
-const config = createJestConfig(
-  relativePath => path.resolve(paths.appPath, "node_modules", paths.scriptVersion, relativePath),
-  path.resolve(paths.appSrc, ".."),
-  false
-);
-// restore overrides for rewireJestConfig
-packageJson.jest = jestOverrides;
 // override createJestConfig in memory
-require.cache[require.resolve(createJestConfigPath)].exports =
-  () => overrides.jest(rewireJestConfig(config));
-// Passing the --scripts-version on to the original test script can result
-// in the test script rejecting it as an invalid option. So strip it out of
-// the command line arguments before invoking the test script.
-if (paths.customScriptsIndex > -1) {
-  process.argv.splice(paths.customScriptsIndex, 2);
-}
+require('../overrides/jest');
+
 // run original script
 require(paths.scriptVersion + '/scripts/test');

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,6 +1,6 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'test';
 
-const { scriptVersion } = require("./utils/paths");
+const { scriptVersion } = require('./utils/paths');
 
 // override paths in memory
 require('../overrides/paths');
@@ -9,4 +9,4 @@ require('../overrides/paths');
 require('../overrides/jest');
 
 // run original script
-require(scriptVersion + '/scripts/test');
+require(`${scriptVersion}/scripts/test`);


### PR DESCRIPTION
`react-scripts` has a `config` folder that contains the base **webpack** or **devServer** configuration. Some 3rd party packages (like [`@storybook/preset-create-react-app`](https://www.npmjs.com/package/@storybook/preset-create-react-app)) require these files, serving as a base for their own configuration.

This PR:
- removes the rewiring-related duplicated code fragments and move them to separate files
- adds the folder `config/webpack.config.js`, `config/webpackDevServer.config.js` and `config/paths.config.js` files that export the **rewired configuration** EVEN if we didn't call the `react-app-rewired` command.

This makes **storybook** (and probably many other packages) plug and play also for the rewired apps.