### PR TITLE
fix: Premature removal of the --config-overrides CLI argument

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -33,11 +33,14 @@ packageJson.jest = jestOverrides;
 // override createJestConfig in memory
 require.cache[require.resolve(createJestConfigPath)].exports =
   () => overrides.jest(rewireJestConfig(config));
-// Passing the --scripts-version on to the original test script can result
+// Passing the --scripts-version and --config-overrides on to the original test script can result
 // in the test script rejecting it as an invalid option. So strip it out of
 // the command line arguments before invoking the test script.
 if (paths.customScriptsIndex > -1) {
   process.argv.splice(paths.customScriptsIndex, 2);
+}
+if (paths.configOverridesIndex > -1) {
+  process.argv.splice(paths.configOverridesIndex, 2);
 }
 // run original script
 require(paths.scriptVersion + '/scripts/test');

--- a/scripts/utils/paths.js
+++ b/scripts/utils/paths.js
@@ -17,9 +17,10 @@ var config_overrides = customPath
   : `${ projectDir }/config-overrides`;
 const co_index = process.argv.indexOf('--config-overrides');
 
+var has_co_argument = false;
 if (co_index > -1 && co_index + 1 <= process.argv.length) {
+  has_co_argument = true;
   config_overrides = path.resolve(process.argv[co_index + 1]);
-  process.argv.splice(co_index, 2);
 }
 
 const scriptVersion = custom_scripts || 'react-scripts';
@@ -33,5 +34,6 @@ const paths = require(modulePath + '/config/paths');
 module.exports = Object.assign({
   scriptVersion: modulePath,
   configOverrides: config_overrides,
-  customScriptsIndex: (custom_scripts ? cs_index : -1)
+  customScriptsIndex: (custom_scripts ? cs_index : -1),
+  configOverridesIndex: (has_co_argument ? co_index : -1),
 }, paths);


### PR DESCRIPTION
Cannot start `test` script if the config-overrides path is set via command-line argument, because it gets removed before the final paths config is done.

Steps to reproduce:
- call the test script like this: `react-app-rewired test --config-overrides path-to-a-config-overrides.js`

The test should not start, even with a correct path, because the config-overrides argument gets stripped out from the `process.argv` array during initialization, and tries to load the `config-overrides.js` from its default location (the project root).

The issue doesn't occur
- if we have a `config-overrides.js` in the project root
- or if we set the config-overrides-path in the project's `package.json`

This hotfix uses the same pattern as we have for removing the --scripts-version argument.