### PR TITLE
docs: alias plugin has been renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ If you need to change the location of your config-overrides.js you can pass a co
 * [react-app-rewired with Inferno](packages/react-app-rewired/examples/inferno.md)
 * [react-app-rewired with react-styleguideist](packages/react-app-rewired/examples/react-styleguidist.md)
 * [react-app-rewired with react-hot-loader](https://github.com/cdharris/react-app-rewire-hot-loader) by [@cdharris](https://github.com/cdharris)
-* [react-app-rewire-alias](https://github.com/oklas/react-app-rewire-alias) by [@oklas](https://github.com/oklas)
+* [react-app-alias](https://github.com/oklas/react-app-alias) by [@oklas](https://github.com/oklas)
 * [react-app-rewire-aliases](https://github.com/aze3ma/react-app-rewire-aliases) by [@aze3ma](https://github.com/aze3ma)
 * [react-app-rewire-blockstack](https://github.com/harrysolovay/react-app-rewire-blockstack) by [@harrysolovay](https://github.com/harrysolovay)
 * [ideal-rewires](https://github.com/harrysolovay/ideal-rewires) by [@harrysolovay](https://github.com/harrysolovay)


### PR DESCRIPTION
Hello

The pligin *react-app-rewire-alias* has been renamed to *react-app-alias*. This is fix the reference.

Thanks